### PR TITLE
Add tools: PatternTrack, SeqP, and GrainSeqP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 out/
 .idea/
 OSR-sync-github.iml
+bin/
+rapid.jar

--- a/src/GrainSeqP.java
+++ b/src/GrainSeqP.java
@@ -1,0 +1,48 @@
+import engine.racedetectionengine.grainSeqP.GrainSeqPEngine;
+import engine.racedetectionengine.grainSeqP.cmd.*;
+import event.Event;
+import event.Lock;
+import event.Thread;
+import event.Variable;
+
+import java.util.ArrayList;
+
+
+public class GrainSeqP {
+    public static void main(String[] args) {	
+        GrainSeqPCmdOptions options = new GrainSeqPGetOptions(args).parse();
+
+        class RunAnalyze extends java.lang.Thread {
+            public GrainSeqPEngine prefixEngine;
+
+            public RunAnalyze(int group) {
+                Variable.variableCountTracker = 0;
+                Thread.threadCountTracker = 0;
+                Lock.lockCountTracker = 0;
+                prefixEngine = new GrainSeqPEngine(options.parserType, options.path, options.doGrainPattern, options.doGrainSize, options.grainSize, options.doLRU, options.LRUSize, group);
+                Event.eventCountTracker = (long)0;
+            }
+
+            @Override
+            public void run() {
+                prefixEngine.analyzeTrace();
+            }
+            
+        }
+
+        ArrayList<RunAnalyze> threads = new ArrayList<>();
+        for(int i = 0; i < 1; i++) {
+            threads.add(new RunAnalyze(i));
+            threads.get(i).start();
+        }
+        for(int i = 0; i < 1; i++) {
+            try {
+                threads.get(i).join();
+            }
+            catch (Exception e) {
+                System.out.println(e);
+            } 
+        }
+        
+	}
+}

--- a/src/PatternLanguage.java
+++ b/src/PatternLanguage.java
@@ -1,0 +1,26 @@
+import cmd.CmdOptions;
+import cmd.GetOptions;
+import engine.pattern.PatternTrack.VectorClockEngine;
+import engine.pattern.ConfPreservingPrefix.PrefixEngine;
+
+public class PatternLanguage {
+    public static void main(String[] args) {		
+		CmdOptions options = new GetOptions(args).parse();
+		String patternFile = args[args.length - 1];
+		// VectorClockEngine engine = new VectorClockEngine(options.parserType, options.path, patternFile);
+		PrefixEngine engine = new PrefixEngine(options.parserType, options.path, patternFile);
+		boolean time_reporting = false;
+		long startTimeAnalysis = 0;
+		if(time_reporting){
+			startTimeAnalysis = System.currentTimeMillis(); //System.nanoTime();
+		}
+		
+		engine.analyzeTrace();
+			
+		if(time_reporting){
+			long stopTimeAnalysis = System.currentTimeMillis(); //System.nanoTime();
+			long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+			System.out.println("Time for full analysis = " + timeAnalysis + " milliseconds");
+		}
+	}
+}

--- a/src/SeqP.java
+++ b/src/SeqP.java
@@ -1,0 +1,12 @@
+import cmd.CmdOptions;
+import cmd.GetOptions;
+import engine.racedetectionengine.seqpreserving.PrefixEngine;
+
+public class SeqP {
+    public static void main(String[] args) {	
+        CmdOptions options = new GetOptions(args).parse();
+       
+        PrefixEngine engine = new PrefixEngine(options.parserType, options.path, true);
+        engine.analyzeTrace(); 
+    }
+}

--- a/src/engine/pattern/Bertoni/BertoniEngine.java
+++ b/src/engine/pattern/Bertoni/BertoniEngine.java
@@ -1,0 +1,13 @@
+package engine.pattern.Bertoni;
+
+import engine.pattern.PatternEngine;
+import parse.ParserType;
+
+public class BertoniEngine extends PatternEngine<BertoniState, BertoniEvent> {
+
+    public BertoniEngine(ParserType pType, String trace_folder, String patternFile) {
+        super(pType, trace_folder, patternFile);
+        handlerEvent = new BertoniEvent();
+        state = new BertoniState(threadSet, pattern);
+    }
+}

--- a/src/engine/pattern/Bertoni/BertoniEvent.java
+++ b/src/engine/pattern/Bertoni/BertoniEvent.java
@@ -1,0 +1,86 @@
+package engine.pattern.Bertoni;
+
+import engine.pattern.PatternEvent;
+import util.vectorclock.VectorClock;
+
+public class BertoniEvent extends PatternEvent<BertoniState> {
+
+    @Override
+    public boolean Handle(BertoniState state) {
+        super.Handle(state);
+        state.history.get(thread).add(this.getTimeStamp(state));
+        return state.computeNonTerm(this.locId, thread);
+    }
+
+
+    private void incrementCurrentThreadClock(BertoniState state, VectorClock vc) {
+        int threadId = state.getThreadIndex(thread);
+        vc.setClockIndex(threadId, vc.getClockIndex(threadId) + 1);
+    }
+
+    public boolean HandleSubAcquire(BertoniState state) {
+        VectorClock L_l = state.getLockClock(lock);
+        VectorClock C_t = state.getThreadClock(thread);
+        C_t.updateWithMax(C_t, L_l);
+        incrementCurrentThreadClock(state, C_t);
+        return false;
+    }
+
+	public boolean HandleSubRelease(BertoniState state) {
+        VectorClock L_l = state.getLockClock(lock);
+        VectorClock C_t = state.getThreadClock(thread);
+        incrementCurrentThreadClock(state, C_t);
+        L_l.copyFrom(C_t);
+        return false;
+    }
+
+	public boolean HandleSubRead(BertoniState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock W_x = state.getWriteClock(variable);
+        VectorClock R_x = state.getReadClock(variable);
+        C_t.updateWithMax(C_t, W_x);
+        incrementCurrentThreadClock(state, C_t);
+        R_x.updateWithMax(R_x, C_t);
+        return false;
+    }
+
+	public boolean HandleSubWrite(BertoniState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock W_x = state.getWriteClock(variable);
+        VectorClock R_x = state.getReadClock(variable);
+        C_t.updateWithMax(C_t, W_x, R_x);
+        incrementCurrentThreadClock(state, C_t);
+        W_x.copyFrom(C_t);
+        return false;
+    }
+
+	public boolean HandleSubFork(BertoniState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock C_u = state.getThreadClock(target);
+        incrementCurrentThreadClock(state, C_t);
+        C_u.copyFrom(C_t);
+        return false;
+    }
+
+	public boolean HandleSubJoin(BertoniState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock C_u = state.getThreadClock(target);
+        C_t.updateWithMax(C_t, C_u);
+        incrementCurrentThreadClock(state, C_t);
+        return false;
+    }
+
+	public boolean HandleSubBegin(BertoniState state) {
+        incrementCurrentThreadClock(state, state.getThreadClock(thread));
+        return false;
+    }
+
+	public boolean HandleSubEnd(BertoniState state) {
+        incrementCurrentThreadClock(state, state.getThreadClock(thread));
+        return false;
+    }
+
+    private VectorClock getTimeStamp(BertoniState state) {
+        return new VectorClock(state.getThreadClock(thread));
+    }
+}

--- a/src/engine/pattern/Bertoni/BertoniState.java
+++ b/src/engine/pattern/Bertoni/BertoniState.java
@@ -1,0 +1,296 @@
+package engine.pattern.Bertoni;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import engine.pattern.State;
+import event.Thread;
+import event.Lock;
+import event.Variable;
+import util.vectorclock.VectorClock;
+
+public class BertoniState extends State {
+    private HashMap<Thread, Integer> threadToIndex = new HashMap<>();
+    public HashMap<Integer, HashSet<Integer>> pattern = new HashMap<>();
+
+    private int numThreads;
+    private int k;
+
+    private HashMap<Thread, VectorClock> threadClock = new HashMap<>();
+    private HashMap<Variable, VectorClock> readClock = new HashMap<>();
+    private HashMap<Variable, VectorClock> writeClock = new HashMap<>();
+    private HashMap<Lock, VectorClock> lockClock = new HashMap<>();
+
+    public HashMap<Thread, ArrayList<VectorClock>> history = new HashMap<>();
+    public ArrayList<TreeMap<Ideal, Integer>> idealToNonTerm = new ArrayList<>();
+    public int idealToNonTermCurrentIndex = 0;
+    public HashMap<Integer, HashMap<Integer, Integer>> specialSym = new HashMap<>();
+    public ArrayList<TreeSet<Ideal>> ideals = new ArrayList<>();
+    public int idealsCurrentIndex = 0;
+
+    private ArrayList<Thread> combination = new ArrayList<>();
+    private ArrayList<Thread> threadList;
+
+    public BertoniState(HashSet<Thread> tSet, ArrayList<Integer> pattern) {
+        numThreads = tSet.size();
+        Iterator<Thread> itThread = tSet.iterator();
+        int index = 0;
+        while(itThread.hasNext()) {
+            Thread thr = itThread.next();
+            threadToIndex.put(thr, index);
+            threadClock.put(thr, emptyClock());
+            history.put(thr, new ArrayList<VectorClock>());
+            specialSym.put(index, new HashMap<>());
+            index++;
+        }
+        
+        idealToNonTerm.add(new TreeMap<>());
+        idealToNonTerm.get(0).put(new Ideal(emptyClock()), -1);
+
+        int cnt = 0;
+        for(int p : pattern) {
+            if(!this.pattern.containsKey(p)) {
+                this.pattern.put(p, new HashSet<Integer>());
+            }
+            this.pattern.get(p).add(cnt++);
+        }
+        this.k = pattern.size();
+        threadList = new ArrayList<Thread>(tSet);
+    }
+
+    public VectorClock emptyClock() {
+        return new VectorClock(numThreads);
+    }
+
+    public VectorClock getThreadClock(Thread t) {
+        return threadClock.get(t);
+    }
+
+    public VectorClock getReadClock(Variable v) {
+        if(!readClock.containsKey(v)) {
+            readClock.put(v, emptyClock());
+        }
+        return readClock.get(v);
+    }
+
+    public VectorClock getWriteClock(Variable v) {
+        if(!writeClock.containsKey(v)) {
+            writeClock.put(v, emptyClock());
+        }
+        return writeClock.get(v);
+    }
+
+    public VectorClock getLockClock(Lock l) {
+        if(!lockClock.containsKey(l)) {
+            lockClock.put(l, emptyClock());
+        }
+        return lockClock.get(l);
+    }
+
+    public int getThreadIndex(Thread thread) {
+        return threadToIndex.get(thread);
+    }
+
+    private void addIdealToNonTerm(Ideal ideal, int sym) {
+        if(idealToNonTerm.get(idealToNonTermCurrentIndex).size() == Integer.MAX_VALUE - 1) {
+            idealToNonTerm.add(new TreeMap<>());
+            idealToNonTermCurrentIndex += 1;
+        }
+        idealToNonTerm.get(idealsCurrentIndex).put(ideal, sym);
+    }
+
+    private int findIdealToNonTerm(Ideal ideal) {
+        for(TreeMap<Ideal, Integer> map: idealToNonTerm) {
+            if(map.containsKey(ideal)){
+                return map.get(ideal);
+            }
+        }
+        return idealToNonTerm.get(idealToNonTermCurrentIndex).get(ideal);
+    }
+
+    private void addIdeal(Ideal ideal) {
+        if(ideals.get(idealsCurrentIndex).size() == Integer.MAX_VALUE - 1) {
+            ideals.add(new TreeSet<>());
+            idealsCurrentIndex += 1;
+        }
+        ideals.get(idealsCurrentIndex).add(ideal);
+    }
+
+    public boolean computeNonTerm(int locId, Thread thread) {
+        if(pattern.containsKey(locId)) {
+            specialSym.get(threadToIndex.get(thread)).
+                    put(threadClock.get(thread).
+                            getClockIndex(threadToIndex.get(thread)), 
+                        locId);
+        }
+        ideals = generateIdeals(threadClock.get(thread), thread);
+        
+        for(TreeSet<Ideal> idealSet: ideals) {
+            for(Ideal ideal: idealSet) {
+                int nonterm = -1;
+                for(int thr: ideal.getMaximalThreads()) {
+                    int maxSym = ideal.getClock().getClockIndex(thr);
+                    ideal.decreaseInThread(thr);
+                    int sym = findIdealToNonTerm(ideal);
+                    if(nonterm < sym) {
+                        nonterm = sym;
+                    }
+                    if(specialSym.get(thr).containsKey(maxSym)) {
+                        int loc = specialSym.get(thr).get(maxSym);
+                        for(int a_i : pattern.get(loc)) {
+                            if(a_i == 0 || (sym == a_i - 1)) {
+                                if(a_i == k - 1) {
+                                    return true;
+                                }
+                                if(nonterm < a_i) {
+                                    nonterm = a_i;
+                                }
+                            }
+                        }
+                    }
+                    ideal.increaseInThread(thr);
+                }
+                if(nonterm >= -1) {
+                    addIdealToNonTerm(ideal, nonterm);
+                }
+            }
+        }
+        return false;
+    }
+
+    private ArrayList<TreeSet<Ideal>> generateIdeals(VectorClock vc, Thread thread) {
+        ideals = new ArrayList<>();
+        ideals.add(new TreeSet<>());
+        idealsCurrentIndex = 0;
+        addIdeal(new Ideal(new VectorClock(vc), new HashSet<Integer>(Arrays.asList(threadToIndex.get(thread)))));
+        
+        generateCombination(0, vc, thread);
+        return ideals;
+    }
+
+    private void generateCombination(int index, VectorClock vc, Thread thread) {
+        for(int i = index; i < threadList.size(); i++) {
+            if(threadList.get(i) == thread) {
+                continue;
+            }
+            combination.add(threadList.get(i));
+            HashMap<Integer, VectorClock> vcs = new HashMap<>();
+            vcs.put(threadToIndex.get(thread), vc);
+            generateIdeal(0, vcs, thread);
+            generateCombination(i + 1, vc, thread);
+            combination.remove(combination.size() - 1);
+        }
+    }
+
+    private void generateIdeal(int index, HashMap<Integer, VectorClock> vcs, Thread thread) {
+        if(index == combination.size()) {
+            VectorClock vc = new VectorClock(numThreads);
+            vc.updateWithMax(vcs.values().toArray(new VectorClock[0]));
+            HashSet<Integer> maxThreads = getMaximalThreads(vcs);
+            if(maxThreads.size() == combination.size() + 1) {
+                addIdeal(new Ideal(vc, maxThreads));
+            }
+        }
+        else {
+            Thread thr = combination.get(index);
+            for(int i = vcs.get(threadToIndex.get(thread)).getClockIndex(threadToIndex.get(thr)); i < history.get(thr).size(); i++) {
+                vcs.put(threadToIndex.get(thr), history.get(thr).get(i));
+                generateIdeal(index + 1, vcs, thread);
+                vcs.remove(threadToIndex.get(thr));
+            }
+        }
+    }
+
+    private HashSet<Integer> getMaximalThreads(HashMap<Integer, VectorClock> vcs) {
+        HashSet<Integer> maximalThreads = new HashSet<>();
+        for(int thr: vcs.keySet()) {
+            boolean flag = true;
+            for(int thr2: vcs.keySet()) {
+                if(thr == thr2) {
+                    continue;
+                }
+                if(vcs.get(thr).isLessThanOrEqual(vcs.get(thr2))) {
+                    flag = false;
+                    break;
+                }
+            }
+            if(flag) {
+                maximalThreads.add(thr);
+            }
+        }
+        return maximalThreads;
+    }
+
+    public void printMemory() {
+        // System.out.println(idealToNonTerm.keySet().size());
+        // System.out.println(ideals.size());
+    }
+}
+
+class Ideal implements Comparable<Ideal> {
+
+    private VectorClock vectorClock;
+    private int sum;
+    private HashSet<Integer> maximalThreads;
+
+    public Ideal(VectorClock vc, HashSet<Integer> mt) {
+        this(vc);
+        maximalThreads = mt;
+    }
+
+    public Ideal(VectorClock vc) {
+        vectorClock = vc;
+        sum = 0;
+        for(int i: vectorClock.getClock()) {
+            sum += i;
+        }
+        maximalThreads = new HashSet<>();
+    }
+
+    public VectorClock getClock() {
+        return vectorClock;
+    }
+
+    public HashSet<Integer> getMaximalThreads() {
+        return maximalThreads;
+    }
+
+    public void decreaseInThread(int threadIndex) {
+        vectorClock.setClockIndex(threadIndex, vectorClock.getClockIndex(threadIndex) - 1);
+        sum -= 1;
+    }
+
+    public void increaseInThread(int threadIndex) {
+        vectorClock.setClockIndex(threadIndex, vectorClock.getClockIndex(threadIndex) + 1);
+        sum += 1;
+    }
+
+    @Override
+	public int compareTo(Ideal other) {
+        if (!(this.vectorClock.getDim() == other.vectorClock.getDim())) {
+			throw new IllegalArgumentException("Mismatch in this.dim and argument.dim");
+		}
+        int sumDiff = this.sum - other.sum;
+		if (sumDiff == 0) {
+			for(int i = 0; i < this.vectorClock.getDim(); i++) {
+                int diff = this.vectorClock.getClockIndex(i) - other.vectorClock.getClockIndex(i);
+                if(diff != 0) {
+                    return diff;
+                }
+            }
+            return 0;
+		} else {
+            return sumDiff;
+        }
+	}
+
+    @Override
+    public String toString() {
+        return vectorClock.toString() + " " + sum + ", " + maximalThreads.toString();
+    }
+}

--- a/src/engine/pattern/ConfPreservingPrefix/PrefixEngine.java
+++ b/src/engine/pattern/ConfPreservingPrefix/PrefixEngine.java
@@ -1,0 +1,163 @@
+package engine.pattern.ConfPreservingPrefix;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Scanner;
+
+import engine.Engine;
+import event.Thread;
+import parse.ParserType;
+import parse.rr.ParseRoadRunner;
+import parse.std.ParseStandard;
+
+public class PrefixEngine extends Engine<PrefixEvent> {
+    protected long eventCount;
+    protected long totalSkippedEvents;
+    
+    protected HashSet<Thread> threadSet;
+    protected HashMap<Integer, String> idToLocationMap = null;
+    protected HashMap<String, Integer> locationToIdMap = null;
+    protected PrefixState state;
+
+    protected ArrayList<Integer> pattern = new ArrayList<>();
+
+    public boolean partition = false;
+    long startTimeAnalysis = 0;
+
+    long interval = 10000000;
+
+    public PrefixEngine(ParserType pType, String trace_folder, String patternFileName) {
+        super(pType);
+        this.initializeReader(trace_folder);
+        try {
+            Scanner myReader = new Scanner(new File(patternFileName));
+            while (myReader.hasNextLine()) {
+                String loc = myReader.nextLine();
+                if(locationToIdMap != null){
+                    // rr
+                    pattern.add(locationToIdMap.get(loc));
+                }
+                else {
+                    // std
+                    pattern.add(Integer.parseInt(loc));
+                }
+            }
+            myReader.close();
+        } catch (FileNotFoundException e) {
+            System.out.println("An error occurred.");
+            e.printStackTrace();
+        }
+        eventCount = 0;
+        totalSkippedEvents = 0;
+        handlerEvent = new PrefixEvent();
+        state = new PrefixState(threadSet, pattern);
+    }
+
+    protected boolean analyzeEvent(PrefixEvent handlerEvent, Long eventCount){
+		boolean patternMatched = false;
+		try{
+			patternMatched = handlerEvent.Handle(state);
+		}
+		catch(OutOfMemoryError oome){
+			System.err.println("Number of events = " + Long.toString(eventCount));
+			state.printMemory();
+            oome.printStackTrace();
+		}
+		return patternMatched;
+	}
+
+    public void analyzeTrace() {
+		if (this.parserType.isRR()) {
+			analyzeTraceRR();
+		}
+        if (this.parserType.isSTD()) {
+			analyzeTraceSTD();
+		}
+		printCompletionStatus();
+		// postAnalysis();
+    }
+
+    private void analyzeTraceRR() {
+        boolean flag = false;
+        startTimeAnalysis = System.currentTimeMillis();
+        long stopTimeAnalysis = 0;
+        ArrayList<Long> stageTime = new ArrayList<>(); 
+        while (rrParser.checkAndGetNext(handlerEvent)) {
+			eventCount = eventCount + 1;
+            if(eventCount % interval == 0) {
+                stageTime.add(System.currentTimeMillis()); 
+            }
+			boolean matched = analyzeEvent(handlerEvent, eventCount);
+            if (matched) {
+                stopTimeAnalysis = System.currentTimeMillis();
+                flag = true;
+                System.out.println("Pattern Matched on the first " + eventCount + " events");
+                break;
+            }
+            postHandleEvent(handlerEvent);
+		}
+        if(!flag) {
+            stopTimeAnalysis = System.currentTimeMillis();
+            System.out.println("Not matched");
+        }
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for full analysis = " + timeAnalysis + " milliseconds");
+        state.printMemory();
+        int cnt = 1;
+        for(long stopTime: stageTime) {
+            timeAnalysis = stopTime - startTimeAnalysis;
+            System.out.println("Time for first " + cnt * interval + " events = " + timeAnalysis + " milliseconds");
+            cnt += 1; 
+        }
+    }
+
+    private void analyzeTraceSTD() {
+        boolean flag = false;
+        while(stdParser.hasNext()){
+			eventCount = eventCount + 1;
+			stdParser.getNextEvent(handlerEvent);
+            boolean matched = analyzeEvent(handlerEvent, eventCount);
+            if (matched) {
+                flag = true;
+                System.out.println("Pattern Matched on the first " + eventCount + " events");
+                break;
+            }
+            postHandleEvent(handlerEvent);
+        }
+        if(!flag) {
+            System.out.println("Not matched");
+        }
+        state.printMemory();
+    }
+
+    protected void initializeReaderRV(String trace_folder) {
+
+    }
+
+	protected void initializeReaderCSV(String trace_file) {
+
+    }
+
+	protected void initializeReaderSTD(String trace_file) {
+        stdParser = new ParseStandard(trace_file, true);
+		threadSet = stdParser.getThreadSet();
+    }
+
+	protected void initializeReaderRR(String trace_file) {
+        rrParser = new ParseRoadRunner(trace_file, true);
+        threadSet = rrParser.getThreadSet();
+        locationToIdMap = rrParser.locationToIdMap;
+    }
+
+    protected boolean skipEvent(PrefixEvent handlerEvent) {
+        // return !handlerEvent.getType().isAccessType();
+        return false;
+    }
+
+	protected void postHandleEvent(PrefixEvent handlerEvent) {
+
+    } 
+}

--- a/src/engine/pattern/ConfPreservingPrefix/PrefixEvent.java
+++ b/src/engine/pattern/ConfPreservingPrefix/PrefixEvent.java
@@ -1,0 +1,84 @@
+package engine.pattern.ConfPreservingPrefix;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import util.Pair;
+
+import engine.pattern.PatternTrack.VectorClockEvent;
+import engine.pattern.PatternTrack.VectorClockState;
+import util.PipedDeepCopy;
+
+public class PrefixEvent extends VectorClockEvent {
+
+    public boolean Handle(PrefixState state) {
+        ArrayList<Pair<VectorClockState, DependentInfo>> newStates = new ArrayList<>();
+        boolean matched = false;
+        
+        boolean threadLocal = this.getType().isTransactionType();
+        for(Iterator<Pair<VectorClockState, DependentInfo>> iterator = state.states.iterator(); iterator.hasNext();){
+            Pair<VectorClockState, DependentInfo> track_state = iterator.next(); 
+            if(!threadLocal && mustIgnore(track_state.second)) {
+                ignore(track_state.second);
+                if(track_state.second.allThreads(state.tSet.size())) {
+                    iterator.remove();
+                }
+            }
+            else {
+                if(!threadLocal /*&& !this.type.isRelease() && !this.type.isRead()*/) {
+                    DependentInfo dep_new = (DependentInfo) PipedDeepCopy.copy(track_state.second);
+                    ignore(dep_new);
+                    if(!dep_new.allThreads(state.tSet.size())) {
+                        VectorClockState copied_state = (VectorClockState) PipedDeepCopy.copy(track_state.first);
+                        newStates.add(new Pair<VectorClockState,DependentInfo>(copied_state, dep_new));
+                    }
+                }
+
+                matched = super.Handle(track_state.first);
+                if(matched) {
+                    return true;
+                }
+                if(this.getType().isWrite()) {
+                    track_state.second.remove(this.variable);
+                }
+                if(this.getType().isAcquire()) {
+                    track_state.second.add(this.lock);
+                }
+                if(this.getType().isRelease()) {
+                    track_state.second.remove(this.lock);
+                }
+            }
+        }
+        state.states.addAll(newStates);
+		return matched;
+	}
+
+    boolean mustIgnore(DependentInfo dep){
+
+        if(this.getType().isAcquire()) {
+            return dep.check_dependency(this.thread) || dep.check_dependency(this.lock);
+        }
+
+        if (this.getType().isRead()) {
+            return dep.check_dependency(this.thread) || dep.check_dependency(this.variable);
+        }
+
+        if(this.getType().isJoin()) {
+            return dep.check_dependency(this.thread) || dep.check_dependency(this.target);
+        }
+
+		return dep.check_dependency(this.thread);
+	}
+
+    void ignore(DependentInfo dep) {
+        dep.add(this.thread);
+
+        if(this.getType().isWrite()) {
+            dep.add(this.variable);
+        }
+
+        if(this.getType().isFork()) {
+            dep.add(this.target);
+        }
+    }
+}

--- a/src/engine/pattern/ConfPreservingPrefix/PrefixState.java
+++ b/src/engine/pattern/ConfPreservingPrefix/PrefixState.java
@@ -1,0 +1,72 @@
+package engine.pattern.ConfPreservingPrefix;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import util.Pair;
+
+import engine.pattern.PatternTrack.VectorClockState;
+import event.Lock;
+import event.Thread;
+import event.Variable;
+import engine.pattern.State;
+
+public class PrefixState extends State {
+    public ArrayList<Pair<VectorClockState, DependentInfo>> states = new ArrayList<>(); 
+    HashSet<Thread> tSet;
+    ArrayList<Integer> pattern;
+
+    public PrefixState(HashSet<Thread> tSet, ArrayList<Integer> pattern) {
+        states.add(new Pair<VectorClockState, DependentInfo>(new VectorClockState(tSet, pattern), new DependentInfo()));
+        this.tSet = tSet;
+        this.pattern = pattern;
+    };
+
+    public void printMemory() {
+        System.out.println(states.size());
+    }
+}
+
+class DependentInfo implements Serializable {
+    HashSet<Thread> tSet = new HashSet<>();
+    HashSet<Variable> wr_vars = new HashSet<>();
+    HashSet<Lock> rel_locks = new HashSet<>();
+
+    public boolean allThreads(int n) {
+        return tSet.size() == n;
+    }
+
+    public boolean check_dependency(Thread t) {
+        return tSet.contains(t);
+    }
+
+    public boolean check_dependency(Variable v) {
+        return wr_vars.contains(v);
+    }
+
+    public boolean check_dependency(Lock l) {
+        return rel_locks.contains(l);
+    }
+
+    public void add(Thread t) {
+        tSet.add(t);
+    }
+
+    public void add(Variable v) {
+        wr_vars.add(v);
+    }
+
+    public void add(Lock l) {
+        rel_locks.add(l);
+    }
+
+    public void remove(Variable v) {
+        wr_vars.remove(v);
+    }
+
+    public void remove(Lock l) {
+        rel_locks.remove(l);
+    }
+
+}

--- a/src/engine/pattern/PatternEngine.java
+++ b/src/engine/pattern/PatternEngine.java
@@ -1,0 +1,160 @@
+package engine.pattern;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Scanner;
+
+import engine.Engine;
+import event.Thread;
+import parse.ParserType;
+import parse.rr.ParseRoadRunner;
+import parse.std.ParseStandard;
+
+public class PatternEngine<S extends State, E extends PatternEvent<S>> extends Engine<E> {
+    protected long eventCount;
+    protected long totalSkippedEvents;
+    
+    protected HashSet<Thread> threadSet;
+    protected HashMap<String, Integer> locationToIdMap = null;
+    protected S state;
+
+    protected ArrayList<Integer> pattern = new ArrayList<>();
+
+    long startTimeAnalysis = 0;
+
+    long interval = 10000000;
+
+    public PatternEngine(ParserType pType, String trace_folder, String patternFileName) {
+        super(pType);
+        this.initializeReader(trace_folder);
+        try {
+            Scanner myReader = new Scanner(new File(patternFileName));
+            while (myReader.hasNextLine()) {
+                String loc = myReader.nextLine();
+                if(locationToIdMap != null){
+                    // rr
+                    pattern.add(locationToIdMap.get(loc));
+                }
+                else {
+                    // std
+                    pattern.add(Integer.parseInt(loc));
+                }
+            }
+            myReader.close();
+        } catch (FileNotFoundException e) {
+            System.out.println("An error occurred.");
+            e.printStackTrace();
+        }
+        eventCount = 0;
+        totalSkippedEvents = 0;
+    }
+
+    protected boolean analyzeEvent(E handlerEvent, Long eventCount){
+		boolean patternMatched = false;
+		try{
+			patternMatched = handlerEvent.Handle(state);
+		}
+		catch(OutOfMemoryError oome){
+			System.err.println("Number of events = " + Long.toString(eventCount));
+			state.printMemory();
+            oome.printStackTrace();
+		}
+		return patternMatched;
+	}
+
+    public void analyzeTrace() {
+		if (this.parserType.isRR()) {
+			analyzeTraceRR();
+		}
+        if (this.parserType.isSTD()) {
+			analyzeTraceSTD();
+		}
+		printCompletionStatus();
+		// postAnalysis();
+    }
+
+    private void analyzeTraceRR() {
+        boolean flag = false;
+        startTimeAnalysis = System.currentTimeMillis();
+        long stopTimeAnalysis = 0;
+        ArrayList<Long> stageTime = new ArrayList<>(); 
+        while (rrParser.checkAndGetNext(handlerEvent)) {
+			eventCount = eventCount + 1;
+            if(eventCount % interval == 0) {
+                stageTime.add(System.currentTimeMillis()); 
+            }
+			boolean matched = analyzeEvent(handlerEvent, eventCount);
+            if (matched) {
+                stopTimeAnalysis = System.currentTimeMillis();
+                flag = true;
+                System.out.println("Pattern Matched on the first " + eventCount + " events");
+                break;
+            }
+            postHandleEvent(handlerEvent);
+		}
+        if(!flag) {
+            stopTimeAnalysis = System.currentTimeMillis();
+            System.out.println("Not matched");
+        }
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for full analysis = " + timeAnalysis + " milliseconds");
+        state.printMemory();
+        int cnt = 1;
+        for(long stopTime: stageTime) {
+            timeAnalysis = stopTime - startTimeAnalysis;
+            System.out.println("Time for first " + cnt * interval + " events = " + timeAnalysis + " milliseconds");
+            cnt += 1; 
+        }
+    }
+
+    private void analyzeTraceSTD() {
+        boolean flag = false;
+        while(stdParser.hasNext()){
+			eventCount = eventCount + 1;
+			stdParser.getNextEvent(handlerEvent);
+            boolean matched = analyzeEvent(handlerEvent, eventCount);
+            if (matched) {
+                flag = true;
+                System.out.println("Pattern Matched on the first " + eventCount + " events");
+                break;
+            }
+            postHandleEvent(handlerEvent);
+        }
+        if(!flag) {
+            System.out.println("Not matched");
+        }
+        state.printMemory();
+    }
+
+    protected void initializeReaderRV(String trace_folder) {
+
+    }
+
+	protected void initializeReaderCSV(String trace_file) {
+
+    }
+
+	protected void initializeReaderSTD(String trace_file) {
+        stdParser = new ParseStandard(trace_file, true);
+		threadSet = stdParser.getThreadSet();
+    }
+
+	protected void initializeReaderRR(String trace_file) {
+        rrParser = new ParseRoadRunner(trace_file, true);
+        threadSet = rrParser.getThreadSet();
+        locationToIdMap = rrParser.locationToIdMap;
+    }
+
+    protected boolean skipEvent(E handlerEvent) {
+        // return !handlerEvent.getType().isAccessType();
+        return false;
+    }
+
+	protected void postHandleEvent(E handlerEvent) {
+
+    }
+
+}

--- a/src/engine/pattern/PatternEvent.java
+++ b/src/engine/pattern/PatternEvent.java
@@ -1,0 +1,54 @@
+package engine.pattern;
+
+import event.Event;
+
+public abstract class PatternEvent<S extends State> extends Event {
+
+    public String toHashString() {
+        String basicInfo = type + "-" + this.getThread();
+        if(type.isAccessType()) {
+            return basicInfo + "-" + this.getVariable();
+        }
+        else if(type.isTransactionType()) {
+            return basicInfo + "-";
+        }
+        else if(type.isLockType()) {
+            return basicInfo + "-" + this.getLock();
+        }
+        else if(type.isExtremeType()) {
+            return basicInfo + "-" + this.getTarget();
+        }
+        else {
+            throw new IllegalArgumentException("Illegal type");
+        }
+    }
+
+	
+	public boolean Handle(S state) {
+		return this.HandleSub(state);
+	}
+	
+	public boolean HandleSub(S state){
+		boolean violationDetected = false;
+
+		if(this.getType().isAcquire()) 	violationDetected = this.HandleSubAcquire(state);
+		if(this.getType().isRelease()) 	violationDetected = this.HandleSubRelease(state);
+		if(this.getType().isRead())		violationDetected = this.HandleSubRead(state);
+		if(this.getType().isWrite())	violationDetected = this.HandleSubWrite(state);
+		if(this.getType().isFork()) 	violationDetected = this.HandleSubFork(state);
+		if(this.getType().isJoin())		violationDetected = this.HandleSubJoin(state);
+		if(this.getType().isBegin())	violationDetected = this.HandleSubBegin(state);
+		if(this.getType().isEnd())		violationDetected = this.HandleSubEnd(state);
+
+		return violationDetected;
+	}
+	
+	public abstract boolean HandleSubAcquire(S state);
+	public abstract boolean HandleSubRelease(S state);
+	public abstract boolean HandleSubRead(S state);
+	public abstract boolean HandleSubWrite(S state);
+	public abstract boolean HandleSubFork(S state);
+	public abstract boolean HandleSubJoin(S state);
+	public abstract boolean HandleSubBegin(S state);
+	public abstract boolean HandleSubEnd(S state);
+}

--- a/src/engine/pattern/PatternTrack/VectorClockEngine.java
+++ b/src/engine/pattern/PatternTrack/VectorClockEngine.java
@@ -1,0 +1,14 @@
+package engine.pattern.PatternTrack;
+
+import engine.pattern.PatternEngine;
+import parse.ParserType;
+
+public class VectorClockEngine extends PatternEngine<VectorClockState, VectorClockEvent> {
+
+    public VectorClockEngine(ParserType pType, String trace_folder, String patternFile) {
+        super(pType, trace_folder, patternFile);
+        handlerEvent = new VectorClockEvent();
+        state = new VectorClockState(threadSet, pattern);
+    }
+
+}

--- a/src/engine/pattern/PatternTrack/VectorClockEvent.java
+++ b/src/engine/pattern/PatternTrack/VectorClockEvent.java
@@ -1,0 +1,88 @@
+package engine.pattern.PatternTrack;
+
+import engine.pattern.PatternEvent;
+import util.vectorclock.VectorClock;
+
+
+public class VectorClockEvent extends PatternEvent<VectorClockState> {
+    
+    @Override
+    public boolean Handle(VectorClockState state) {
+        super.Handle(state);
+        return state.extendWitness(this.locId, this.thread, this.getTimeStamp(state));
+    }
+
+    private void incrementCurrentThreadClock(VectorClockState state, VectorClock vc) {
+        int threadId = state.getThreadIndex(thread);
+        vc.setClockIndex(threadId, vc.getClockIndex(threadId) + 1);
+    }
+
+    public boolean HandleSubAcquire(VectorClockState state) {
+        VectorClock L_l = state.getLockClock(lock);
+        VectorClock C_t = state.getThreadClock(thread);
+        C_t.updateWithMax(C_t, L_l);
+        incrementCurrentThreadClock(state, C_t);
+        return false;
+    }
+
+	public boolean HandleSubRelease(VectorClockState state) {
+        VectorClock L_l = state.getLockClock(lock);
+        VectorClock C_t = state.getThreadClock(thread);
+        incrementCurrentThreadClock(state, C_t);
+        L_l.copyFrom(C_t);
+        return false;
+    }
+
+	public boolean HandleSubRead(VectorClockState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock W_x = state.getWriteClock(variable);
+        VectorClock R_x = state.getReadClock(variable);
+        C_t.updateWithMax(C_t, W_x);
+        incrementCurrentThreadClock(state, C_t);
+        R_x.updateWithMax(R_x, C_t);
+        return false;
+    }
+
+	public boolean HandleSubWrite(VectorClockState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock W_x = state.getWriteClock(variable);
+        VectorClock R_x = state.getReadClock(variable);
+        C_t.updateWithMax(C_t, W_x, R_x);
+        incrementCurrentThreadClock(state, C_t);
+        W_x.copyFrom(C_t);
+        return false;
+    }
+
+	public boolean HandleSubFork(VectorClockState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock C_u = state.getThreadClock(target);
+        incrementCurrentThreadClock(state, C_t);
+        C_u.copyFrom(C_t);
+        C_u.setClockIndex(state.getThreadIndex(target), 1);
+        return false;
+    }
+
+	public boolean HandleSubJoin(VectorClockState state) {
+        VectorClock C_t = state.getThreadClock(thread);
+        VectorClock C_u = state.getThreadClock(target);
+        C_t.updateWithMax(C_t, C_u);
+        incrementCurrentThreadClock(state, C_t);
+        return false;
+    }
+
+	public boolean HandleSubBegin(VectorClockState state) {
+        incrementCurrentThreadClock(state, state.getThreadClock(thread));
+        return false;
+    }
+
+	public boolean HandleSubEnd(VectorClockState state) {
+        incrementCurrentThreadClock(state, state.getThreadClock(thread));
+        return false;
+    }
+
+    private VectorClock getTimeStamp(VectorClockState state) {
+        return new VectorClock(state.getThreadClock(thread));
+    }
+}
+
+

--- a/src/engine/pattern/PatternTrack/VectorClockState.java
+++ b/src/engine/pattern/PatternTrack/VectorClockState.java
@@ -1,0 +1,128 @@
+package engine.pattern.PatternTrack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+
+import util.Pair;
+
+import engine.pattern.State;
+import event.Thread;
+import event.Lock;
+import event.Variable;
+import util.vectorclock.VectorClock;
+
+public class VectorClockState extends State {
+    private HashMap<Thread, Integer> threadToIndex = new HashMap<>();
+    public HashMap<ArrayList<Pair<Thread, Integer>> , ArrayList<VectorClock>> currentState = new HashMap<>();
+    public HashMap<Integer, HashSet<Integer>> pattern = new HashMap<>();
+
+    private int numThreads;
+    private int k;
+
+    private HashMap<Thread, VectorClock> threadClock = new HashMap<>();
+    private HashMap<Variable, VectorClock> readClock = new HashMap<>();
+    private HashMap<Variable, VectorClock> writeClock = new HashMap<>();
+    private HashMap<Lock, VectorClock> lockClock = new HashMap<>();
+
+    public VectorClockState(HashSet<Thread> tSet, ArrayList<Integer> pattern) {
+        numThreads = tSet.size();
+        Iterator<Thread> itThread = tSet.iterator();
+        int index = 0;
+        while(itThread.hasNext()) {
+            Thread thr = itThread.next();
+            threadToIndex.put(thr, index);
+            index++;
+            threadClock.put(thr, emptyClock());
+        }
+        currentState.put(new ArrayList<>(), new ArrayList<>());
+        int cnt = 0;
+        for(int p : pattern) {
+            if(!this.pattern.containsKey(p)) {
+                this.pattern.put(p, new HashSet<Integer>());
+            }
+            this.pattern.get(p).add(cnt++);
+        }
+        this.k = pattern.size();
+    }
+
+    public VectorClock emptyClock() {
+        return new VectorClock(numThreads);
+    }
+
+    public VectorClock getThreadClock(Thread t) {
+        return threadClock.get(t);
+    }
+
+    public VectorClock getReadClock(Variable v) {
+        if(!readClock.containsKey(v)) {
+            readClock.put(v, emptyClock());
+        }
+        return readClock.get(v);
+    }
+
+    public VectorClock getWriteClock(Variable v) {
+        if(!writeClock.containsKey(v)) {
+            writeClock.put(v, emptyClock());
+        }
+        return writeClock.get(v);
+    }
+
+    public VectorClock getLockClock(Lock l) {
+        if(!lockClock.containsKey(l)) {
+            lockClock.put(l, emptyClock());
+        }
+        return lockClock.get(l);
+    }
+
+    public int getThreadIndex(Thread thread) {
+        return threadToIndex.get(thread);
+    }
+
+    public boolean extendWitness(int locId, Thread thread, VectorClock vc) {
+        if(pattern.containsKey(locId)) {
+            HashMap<ArrayList<Pair<Thread, Integer>> , ArrayList<VectorClock>> newStates = new HashMap<>();
+            for (int index : pattern.get(locId)) {
+                for(ArrayList<Pair<Thread, Integer>> witness: currentState.keySet()) {
+                    if(witnesses(index, vc, witness, currentState.get(witness))) {
+                        if(witness.size() == k - 1) {
+                            return true;
+                        }
+                        ArrayList<Pair<Thread, Integer>> extendedWitness = new ArrayList<>();
+                        extendedWitness.addAll(witness);
+                        extendedWitness.add(new Pair<Thread, Integer>(thread, index));
+                        ArrayList<VectorClock> extendedTimeStamps = new ArrayList<>();
+                        extendedTimeStamps.addAll(currentState.get(witness));
+                        extendedTimeStamps.add(vc);
+                        newStates.put(extendedWitness, extendedTimeStamps);
+                    }
+                }
+            }
+            currentState.putAll(newStates);
+        }
+        return false;
+    }
+
+    private boolean witnesses(int index, VectorClock vc, ArrayList<Pair<Thread, Integer>> witness, ArrayList<VectorClock> timestamps) {
+        Iterator<Pair<Thread, Integer>> itWitness = witness.iterator();
+        Iterator<VectorClock> itTimestamp = timestamps.iterator();
+        while(itWitness.hasNext()) {
+            Pair<Thread, Integer> event2 = itWitness.next();
+            if(event2.first.getId() == index) {
+                return false;
+            }
+            VectorClock timeStamp = itTimestamp.next();
+            if(event2.first.getId() > index &&
+                timeStamp.isLessThanOrEqual(vc)) {
+                    return false;
+                }
+        }
+        return true;
+    }
+
+    public void printMemory() {
+        // System.out.println(currentState.keySet());
+    }
+}
+

--- a/src/engine/pattern/State.java
+++ b/src/engine/pattern/State.java
@@ -1,0 +1,13 @@
+package engine.pattern;
+
+import java.util.ArrayList;
+import java.io.Serializable;
+
+public class State implements Serializable {
+
+    public State(ArrayList<Integer> pattern) {};
+
+    public State() {};
+
+    public void printMemory() {}
+}

--- a/src/engine/racedetectionengine/grainSeqP/GrainSeqPEngine.java
+++ b/src/engine/racedetectionengine/grainSeqP/GrainSeqPEngine.java
@@ -1,0 +1,159 @@
+package engine.racedetectionengine.grainSeqP;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashSet;
+
+import engine.Engine;
+import engine.racedetectionengine.seqpreserving.preprocess.PreprocessEngine;
+import parse.ParserType;
+import parse.rr.ParseRoadRunner;
+import parse.std.ParseStandard;
+
+public class GrainSeqPEngine extends Engine<GrainSeqPEvent> {
+    protected long eventCount;
+    protected long totalSkippedEvents;
+
+    protected int numOfThreads;
+    protected int numOfVars;
+    protected int numOfLocks;
+
+    protected State state;
+    protected String sourceFile;
+
+    HashSet<Long> racyevents = new HashSet<>();
+    HashSet<Integer> racyLocs = new HashSet<>();
+    HashSet<Integer> protectedVars;
+    HashSet<Long> orderedEvents;
+
+    public boolean partition = false;
+    long startTimeAnalysis = 0;
+
+    public GrainSeqPEngine(ParserType pType, String trace_folder, boolean doGrainPattern, boolean doGrainSize, int grainSize, boolean doLRU, double LRUsize, int group) {
+        super(pType);
+        sourceFile = trace_folder;
+        eventCount = 0;
+        totalSkippedEvents = 0;
+        this.initializeReader(trace_folder);
+        resetSTDParser();
+        PreprocessEngine engine = new PreprocessEngine(pType, trace_folder, stdParser);
+        engine.analyzeTrace();
+        protectedVars = engine.getProtectedVars();
+        resetSTDParser();
+
+        handlerEvent = new GrainSeqPEvent();
+        eventCount = 0;
+        state = new State(numOfThreads, numOfVars, numOfLocks, doGrainPattern, doGrainSize, grainSize, doLRU, LRUsize, protectedVars, orderedEvents, group);
+    }
+
+    protected void analyzeEvent(GrainSeqPEvent handlerEvent, Long eventCount){
+		
+	}
+
+    public void analyzeTrace() {
+		if (this.parserType.isRR()) {
+			analyzeTraceRR();
+		}
+        if (this.parserType.isSTD()) {
+			analyzeTraceSTD();
+		}
+		printCompletionStatus();
+    }
+
+    private void analyzeTraceRR() {
+        boolean flag = false;
+        startTimeAnalysis = System.currentTimeMillis();
+        long stopTimeAnalysis = 0;
+        while(rrParser.checkAndGetNext(handlerEvent)) {
+            eventCount = eventCount + 1;
+            analyzeEvent(handlerEvent, eventCount);
+            postHandleEvent(handlerEvent);
+        }
+        if(!flag) {
+            stopTimeAnalysis = System.currentTimeMillis();
+            System.out.println("Not matched");
+        }
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for full analysis = " + timeAnalysis + " milliseconds");
+    }
+
+    private void analyzeTraceSTD() {
+        long maxState = 0;
+        long maxBirth = 0;
+        long startTimeAnalysis = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
+        maxState = 0;
+        while(stdParser.hasNext()){
+            eventCount = eventCount + 1;
+            stdParser.getNextEvent(handlerEvent);
+            try{
+                if(handlerEvent.Handle(state)) {
+                    racyevents.add(eventCount);
+                    racyLocs.add(handlerEvent.getLocId());
+                    
+                }
+                maxBirth += state.getSize();
+            }
+            catch(OutOfMemoryError oome){
+                System.err.println("Number of events = " + Long.toString(eventCount));
+                state.printMemory();
+                oome.printStackTrace();
+            }
+            
+            if(eventCount % 10000 == 0) {
+                long end = System.currentTimeMillis();
+                System.out.println(eventCount + " " + (end - start) + " " + 1.0 * maxBirth / 10000 + " " + racyevents.size() + " " + racyLocs.size());
+                start = System.currentTimeMillis();
+                maxBirth = 0;
+            }
+            
+            postHandleEvent(handlerEvent);
+        }
+        long stopTimeAnalysis = System.currentTimeMillis();
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for analysis = " + timeAnalysis + " milliseconds");
+        System.out.println("Max State Size = " + maxState + " birth = " + maxBirth);
+        System.out.println("Racy events = " + racyevents);
+        System.out.println("Racy locations = " + racyLocs);
+        System.out.println("Number of 'racy' events found = " + racyevents.size());
+    }
+
+    protected void initializeReaderRV(String trace_folder) {
+
+    }
+
+	protected void initializeReaderCSV(String trace_file) {
+
+    }
+
+	protected void initializeReaderSTD(String trace_file) {
+        stdParser = new ParseStandard(trace_file, true);
+        numOfThreads = stdParser.getNumOfThreads();
+        numOfVars = stdParser.getNumOfVars();
+        numOfLocks = stdParser.getNumOfLocks();
+    }
+
+	protected void initializeReaderRR(String trace_file) {
+        rrParser = new ParseRoadRunner(trace_file, true);
+    }
+
+    protected void resetSTDParser() {
+        stdParser.totEvents = 0;
+        try{
+            stdParser.bufferedReader = new BufferedReader(new FileReader(sourceFile));
+        }
+        catch (FileNotFoundException ex) {
+            System.out.println("Unable to open file '" + sourceFile + "'");
+        }
+    }
+
+    protected boolean skipEvent(GrainSeqPEvent handlerEvent) {
+        // return !handlerEvent.getType().isAccessType();
+        return false;
+    }
+
+	protected void postHandleEvent(GrainSeqPEvent handlerEvent) {
+
+    } 
+}

--- a/src/engine/racedetectionengine/grainSeqP/GrainSeqPEvent.java
+++ b/src/engine/racedetectionengine/grainSeqP/GrainSeqPEvent.java
@@ -1,0 +1,11 @@
+package engine.racedetectionengine.grainSeqP;
+
+import event.Event;
+
+public class GrainSeqPEvent extends Event {
+	public long eventCount = 0;
+    public boolean Handle(State state) {
+		eventCount += 1;
+		return state.update(this);
+	}   
+}

--- a/src/engine/racedetectionengine/grainSeqP/State.java
+++ b/src/engine/racedetectionengine/grainSeqP/State.java
@@ -1,0 +1,975 @@
+package engine.racedetectionengine.grainSeqP;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.PriorityQueue;
+import java.util.Map.Entry;
+import java.util.BitSet;
+import event.EventType;
+
+public class State {
+
+    public HashMap<Integer, HashMap<String, DependentInfo>> statesPhase0 = new HashMap<>();
+    public HashMap<String, DependentInfo> statesPhase1 = new HashMap<>(); 
+    public HashMap<Integer, HashMap<String, DependentInfo>> statesPhase2 = new HashMap<>();
+    public HashMap<String, DependentInfo> statesPhase3 = new HashMap<>();  
+    public static int numOfThreads;
+    public static int numOfVariables;
+    public static int numOfLocks;
+    public int raceCnt = 0;
+    public boolean racy = false;
+    public long timestamp;
+    private long poolSize;
+    private int sizelimit;
+    public long stateSize;
+    private int group;
+
+    public PriorityQueue<Long> birthsPhase0 = new PriorityQueue<>();
+    public PriorityQueue<Long> birthsPhase1 = new PriorityQueue<>();
+    public PriorityQueue<Long> birthsPhase2 = new PriorityQueue<>();
+    public PriorityQueue<Long> birthsPhase3 = new PriorityQueue<>();  
+    private HashMap<Integer, HashMap<Integer, Integer>> lockHold = new HashMap<>();
+    private HashMap<Integer, HashMap<Integer, Integer>> lockHold2 = new HashMap<>();
+    public HashSet<Integer> racyLocs = new HashSet<>();
+    HashSet<Integer> protectedVars;
+    HashSet<Long> orderedEvents;
+    
+    boolean grainPattern = false;
+    boolean grainSize = false;
+    boolean LRU = false;
+    long eventCount;
+    int oneChoice = 0;
+    int twoChoices = 0;
+
+    public long getSize() {
+        return birthsPhase0.size() + birthsPhase1.size() + birthsPhase2.size() + birthsPhase3.size();
+    }
+
+    public State(int numOfThrs, int numOfVars, int numOfLcks, boolean doGrainPattern, boolean doGrainSize, int grainSize, boolean doLRU, double LRUsize, HashSet<Integer> protectedVars, HashSet<Long> orderedEvents, int group) {
+        numOfThreads = numOfThrs;
+        numOfVariables = numOfVars;
+        numOfLocks = numOfLcks;
+        this.protectedVars = protectedVars;
+        this.orderedEvents = orderedEvents;
+        this.group = group;
+
+        if(doGrainPattern) {
+            grainPattern = true;
+        }
+        if(doGrainSize) {
+            this.grainSize = true;
+            sizelimit = grainSize;
+            
+        }
+        if(doLRU) {
+            this.LRU = true;
+            this.poolSize = (long)LRUsize;
+        }
+        if(LRU) System.out.println("LRU size " + this.poolSize);
+        if(grainPattern) System.out.println("Grain Pattern");
+        if(this.grainSize) System.out.println("G1 size " + this.sizelimit);
+        System.out.println("Batch Number " + this.group);
+        DependentInfo dep0 = new DependentInfo();
+        dep0.hashString = dep0.toString();
+        HashMap<String, DependentInfo> substates = new HashMap<>();
+        substates.put(dep0.hashString, dep0);
+        statesPhase0.put(-1, substates);
+        DependentInfo dep1 = new DependentInfo();
+        dep1.pin = true;
+        dep1.hashString = dep1.toString();
+        statesPhase1.put(dep1.hashString, dep1);
+    };
+
+    public boolean update(GrainSeqPEvent e) {
+        int eThr = e.getThread().getId();
+        int eDec = -1;
+        int eType = e.getType().ordinal();
+        if(e.getType().isAccessType()) {
+            eDec = e.getVariable().getId();
+        }
+        else if(e.getType().isLockType()) {
+            eDec = e.getLock().getId();
+        }
+        else if(e.getType().isExtremeType()) {
+            eDec = e.getTarget().getId();
+        } 
+        eventCount = e.eventCount;
+
+        racy = false;
+        timestamp++;
+        if(!lockHold.containsKey(eThr)) {
+			lockHold.put(eThr, new HashMap<>());
+		}
+        if(!lockHold2.containsKey(eThr)) {
+			lockHold2.put(eThr, new HashMap<>());
+		}
+        updateLockHold(lockHold2, eThr, eDec, eType);
+        stateSize = 0; 
+        updatePhase02(eThr, eDec, eType, 0);
+        updatePhase1(eThr, eDec, eType);
+        updatePhase02(eThr, eDec, eType, 2);
+        updatePhase3(eThr, eDec, eType);
+        // stateSize = statesPhase0.size() + statesPhase1.size() + statesPhase2.size() + statesPhase3.size();
+        updateLockHold(lockHold, eThr, eDec, eType);
+        return racy;
+    }
+
+    private void updateLockHold(HashMap<Integer, HashMap<Integer, Integer>> lockHold,int eThr, int eDec, int eType) {
+        if(eType == EventType.ACQUIRE.ordinal()) {
+            if(!lockHold.get(eThr).containsKey(eDec)) {
+                lockHold.get(eThr).put(eDec, 0);
+            }
+			lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) + 1);
+		}
+		if(eType == EventType.RELEASE.ordinal()) {
+			assert(lockHold.get(eThr).get(eDec) > 0);
+            lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) - 1);
+            if(lockHold.get(eThr).get(eDec) == 0) {
+                lockHold.get(eThr).remove(eDec);
+            }
+		}
+    }
+
+    private void updatePhase02(int eThr, int eDec, int eType, int phase) {
+        HashMap<Integer, HashMap<String, DependentInfo>> states = phase == 0 ? statesPhase0 : statesPhase2;
+        HashMap<Integer, HashMap<String, DependentInfo>> newStates = new HashMap<>();
+        PriorityQueue<Long> births = phase == 0 ? birthsPhase0 : birthsPhase2;
+        PriorityQueue<Long> newBirths = new PriorityQueue<>();
+        for(int var: states.keySet()) {
+            HashMap<String, DependentInfo> substates = states.get(var);
+            for(String hashString: substates.keySet()){
+                
+                stateSize += 1;
+                DependentInfo dep = substates.get(hashString);
+                long birth = dep.birth;
+                
+                if(LRU) {
+                    if(!dep.pin && !births.isEmpty() && births.size() >= poolSize - 1 && birth <= births.peek() && birth != 0) {
+                        continue;
+                    }
+                }
+
+                if((phase == 0 && (eType == EventType.ACQUIRE.ordinal() || ((eType == EventType.WRITE.ordinal() || eType == EventType.READ.ordinal()) && choose(eDec)))) || (phase == 2 && (!grainPattern || (eThr != dep.e1Thr && ((eType == EventType.WRITE.ordinal() && dep.e1Var == eDec)|| (eType == EventType.READ.ordinal() && dep.e1Write)) )))) {
+                    DependentInfo depCopied = new DependentInfo(dep);
+                    if(depCopied.checkLock(eThr, lockHold, phase + 1)){
+                        if(phase == 0) {
+                            depCopied.pin = true;
+                            depCopied.birth = timestamp;
+                        }
+                        if(phase == 2 && grainPattern) {
+                            depCopied.rdFrontier = null;
+                            depCopied.acqFrontier = null;
+                            // dep.G1Time += 1;
+                        }
+                        depCopied.hashString = depCopied.toString();
+                        HashMap<String, DependentInfo> nextPhase = phase == 0 ? statesPhase1 : statesPhase3; 
+                        PriorityQueue<Long> nextBirths = phase == 0 ? birthsPhase1 : birthsPhase3;
+                        addToStates13(nextPhase, nextBirths, depCopied, depCopied.birth, phase);
+                    }
+                }
+                if(dep.mustIgnore(eThr, eDec, eType)) {
+                    DependentInfo depCopied = new DependentInfo(dep);
+                    if(depCopied.ignore(eThr, eDec, eType, lockHold, phase)) {
+                        addToStates02(newStates, newBirths, depCopied, birth, phase);
+                    }
+                }
+                else {
+                    if(phase == 2) {
+                        if(eType == EventType.ACQUIRE.ordinal()/*  && dep.activeAcq < 5*/) {
+                            DependentInfo depCopied = new DependentInfo(dep);
+                            // depCopied.activeAcq += 1;
+                            if(depCopied.ignore(eThr, eDec, eType, lockHold, phase)) {
+                                if(birth == 0) {
+                                    addToStates02(newStates, newBirths, depCopied, timestamp, phase); 
+                                }
+                                else {
+                                    addToStates02(newStates, newBirths, depCopied, birth, phase);
+                                }
+                                
+                            }
+                        }
+                    }
+                    
+                        
+                    // }
+
+                    // II. Keep event e:
+                    boolean flag = true;
+                    DependentInfo depCopied = new DependentInfo(dep); 
+                    if (phase == 2) {
+                        depCopied.inclThreadsAftG1.set(eThr);
+                    }
+                    
+                    if(eType == EventType.WRITE.ordinal()) {
+                        if(phase == 0)
+                            depCopied.exclWtVarsBefG1.clear(eDec);
+                        else {
+                            depCopied.exclWtVarsAftG1.clear(eDec);
+                            depCopied.inclWtVarsAftG1.set(eDec);
+                            if(depCopied.rdFrontier.containsKey(eDec)) {
+                                MazFrontier fr = depCopied.rdFrontier.get(eDec);
+                                if(fr.isDependentWithE1) {
+                                    flag = false;
+                                }
+                                else {
+                                    depCopied.Frontier.union(fr);
+                                }
+                            }
+                        }
+                    } 
+                    
+                    if(flag) {
+                        addToStates02(newStates, newBirths, depCopied, birth, phase);
+                    }
+                    
+                }
+            }
+        }
+        if(phase == 0) {
+            statesPhase0 = newStates;
+            birthsPhase0 = newBirths;
+        }
+        else {
+            statesPhase2 = newStates;
+            birthsPhase2 = newBirths;
+        }
+    }
+
+    private boolean choose(int eDec) {
+        // return true;
+        return /*!orderedEvents.contains(eventCount) && */
+            eDec % 1 == group && !protectedVars.contains(eDec);
+        // if(numOfThreads == 10) {
+        //     return !protectedVars.contains(eDec);
+        // }
+        // else {
+        //     return eDec % 94 == group; 
+        // }
+    }
+
+    private void updatePhase1(int eThr, int eDec, int eType) {
+        HashMap<String, DependentInfo> newStates = new HashMap<>();
+        PriorityQueue<Long> newBirths = new PriorityQueue<>();
+        for(String hashString: statesPhase1.keySet()){
+            stateSize += 1;
+            DependentInfo dep = statesPhase1.get(hashString);
+            long birth = dep.birth;
+            // if(eventCount == 9) {
+            //     System.out.println(dep.toString());
+            // }
+            if(LRU) {
+                if(!dep.pin && !birthsPhase1.isEmpty() && birthsPhase1.size() >= poolSize - 1 && birth <= birthsPhase1.peek()  && birth != 0) {
+                    continue;
+                }
+            }
+            // else if(heuristic == 2) {
+            //     if(timestamp - birth >= lifetime) {
+            //         continue;
+            //     }
+            // }
+            if(grainSize) {
+                if(dep.G1Size + dep.G2Size > sizelimit) {
+                    continue;
+                }
+            }
+            boolean force = false;
+            if(dep.e1Thr != -1 && (!grainPattern || (dep.G1Size == 1 || (eType == EventType.RELEASE.ordinal() && (eDec == dep.e1Acq))))) {
+                force = true;
+                DependentInfo depCopied = new DependentInfo(dep);
+                if(dep.G1Size == 1) {
+                    depCopied.pin = true;
+                }
+                depCopied.hashString = depCopied.toString();
+                if(!statesPhase2.containsKey(depCopied.e1Var)) {
+                    statesPhase2.put(depCopied.e1Var, new HashMap<>());
+                }
+                HashMap<String, DependentInfo> substates = statesPhase2.get(depCopied.e1Var);
+                if(!substates.containsKey(depCopied.hashString)) {
+                    addToStates02(statesPhase2, birthsPhase2, depCopied, depCopied.birth, 2);
+                }
+            }
+            if(grainPattern && !dep.thrG1.isEmpty() && !dep.thrG1.get(eThr)) {
+                continue;
+            }
+            if(!grainPattern || !force) {
+            {
+                dep.G1Size += 1;
+                if(dep.G1Size > 1 || (eType == EventType.ACQUIRE.ordinal())) {
+                DependentInfo depCopied = new DependentInfo(dep);
+                if(depCopied.checkLock(eThr, lockHold, 1))  {
+                    if(depCopied.G1Size == 1 && eType == EventType.ACQUIRE.ordinal()) {
+                        depCopied.e1Acq = eDec;
+                    }
+                    depCopied.pin = false;
+                    if(!depCopied.thrG1.get(eThr) && depCopied.exclThreadsBefG1.get(eThr)) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                    if(eType == EventType.JOIN.ordinal()) {
+                        if(!depCopied.thrG1.get(eDec) && depCopied.exclThreadsBefG1.get(eDec)) {
+                            depCopied.Frontier.update(eThr, eDec, eType);
+                        }
+                    }
+                    depCopied.thrG1.set(eThr);
+                    depCopied.exclThreadsBefG1.set(eThr);
+                    if(eType == EventType.FORK.ordinal() || eType == EventType.JOIN.ordinal()) {
+                        depCopied.exclThreadsBefG1.set(eDec);
+                    }
+                    if(eType == EventType.READ.ordinal() && !depCopied.wtG1.get(eDec)) {
+                        if(depCopied.exclWtVarsBefG1.get(eDec)) {
+                            depCopied.Frontier.update(eThr, eDec, eType);
+                        }
+                        else {
+                            if(!depCopied.rdFrontier.containsKey(eDec)) {
+                                depCopied.rdFrontier.put(eDec, new MazFrontier());
+                            }
+                            depCopied.rdFrontier.get(eDec).update(eThr, eDec, eType);
+                        }
+                    }
+                     
+                    if(eType == EventType.WRITE.ordinal()) {
+                        depCopied.wtG1.set(eDec);
+                        depCopied.exclWtVarsBefG1.set(eDec);
+                    }
+                    if(eType == EventType.ACQUIRE.ordinal()) {
+                        if(depCopied.openLocks.get(eDec)) {
+                            depCopied.Frontier.update(eThr, eDec, eType);
+                        }
+                        else {
+                            if(!depCopied.acqFrontier.containsKey(eDec)) {
+                                depCopied.acqFrontier.put(eDec, new MazFrontier());
+                            }
+                            depCopied.acqFrontier.get(eDec).update(eThr, eDec, eType);
+                        }
+                        depCopied.openLocksG1.set(eDec);
+                    }
+                    if(eType == EventType.RELEASE.ordinal()) {
+                        depCopied.openLocksG1.clear(eDec);
+                    }
+                    if(depCopied.Frontier.isDependentWith(eThr, eDec, eType)) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                    if(eThr == depCopied.e1Thr || ((eType == EventType.WRITE.ordinal() || (eType == EventType.READ.ordinal() && depCopied.e1Write)) && depCopied.e1Var == eDec) || ((eType == EventType.FORK.ordinal() || eType == EventType.JOIN.ordinal()) && eDec == depCopied.e1Thr)) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                    for(int var: depCopied.rdFrontier.keySet()) {
+                        MazFrontier fr = depCopied.rdFrontier.get(var);
+                        if(fr.isDependentWith(eThr, eDec, eType)) {
+                            fr.update(eThr, eDec, eType);
+                        }
+                    }
+                    for(int lck: depCopied.acqFrontier.keySet()) {
+                        MazFrontier fr = depCopied.acqFrontier.get(lck);
+                        if(fr.isDependentWith(eThr, eDec, eType)) {
+                            fr.update(eThr, eDec, eType);
+                        }
+                    }
+                    addToStates13(newStates, newBirths, depCopied, birth, 1);
+                }
+            }
+            }
+            // choose as e1
+            {
+                if(dep.e1Thr == -1 && (eType == EventType.READ.ordinal() || eType == EventType.WRITE.ordinal()) && choose(eDec)) {
+                    if((dep.thrG1.get(eThr) || !dep.exclThreadsBefG1.get(eThr)) && !dep.Frontier.isDependentWith(eThr, eDec, eType)) {
+                        boolean flag = true;
+                        DependentInfo depCopied = new DependentInfo(dep);
+                        if(depCopied.ignore(eThr, eDec, eType, lockHold, 1)) {
+                            depCopied.e1Thr = eThr;
+                            depCopied.e1Var = eDec;
+                            depCopied.e1Write = eType == EventType.WRITE.ordinal();
+                            depCopied.thrG1.set(eThr);
+                            if(depCopied.e1Write) {
+                                depCopied.wtG1.set(eDec);
+                            }
+                            
+                            for(int var: depCopied.rdFrontier.keySet()) {
+                                MazFrontier fr = depCopied.rdFrontier.get(var);
+                                if(fr.isDependentWith(eThr, eDec, eType)) {
+                                    fr.isDependentWithE1 = true;
+                                    fr.update(eThr, eDec, eType);
+                                }
+                            }
+                            for(int lck: depCopied.acqFrontier.keySet()) {
+                                MazFrontier fr = depCopied.acqFrontier.get(lck);
+                                if(fr.isDependentWith(eThr, eDec, eType)) {
+                                    fr.isDependentWithE1 = true;
+                                    fr.update(eThr, eDec, eType);
+                                }
+                            } 
+                            if(flag){
+                                addToStates13(newStates, newBirths, depCopied, birth, 1);
+                            }
+                        }
+
+                    }
+                }
+            }
+            }
+        }
+        statesPhase1 = newStates;
+        birthsPhase1 = newBirths;
+    }
+
+    private void updatePhase3(int eThr, int eDec, int eType) {
+        HashMap<String, DependentInfo> newStates = new HashMap<>();
+        PriorityQueue<Long> newBirths = new PriorityQueue<>();
+        for(String hashString: statesPhase3.keySet()){
+            stateSize += 1;
+            DependentInfo dep = statesPhase3.get(hashString);
+            long birth = dep.birth;
+            if(LRU) {
+                if(!dep.pin && !birthsPhase3.isEmpty() && birth < birthsPhase3.peek() && birth != 0) {
+                    continue;
+                }
+            }
+            // if(eventCount == 9 && dep.e1Write && dep.e1Var == 0 && dep.e1Thr == 0) {
+            //     System.out.println(dep.toString());
+            // }
+            // else if(heuristic == 2) {
+            //     if(timestamp - birth >= lifetime) {
+            //         continue;
+            //     }
+            // }
+
+            if(grainSize) {
+                if(dep.G1Size + dep.G2Size > sizelimit) {
+                    continue;
+                }
+            }
+
+            if(grainPattern && !dep.thrG2.isEmpty() && !dep.thrG2.get(eThr)) {
+                continue;
+            }
+            if(!grainPattern || eType == EventType.READ.ordinal()) {
+                dep.G2Size += 1;
+                if(dep.G2Size > 1) {
+                    dep.pin = false;
+                }
+                DependentInfo depCopied = new DependentInfo(dep);  
+                if(depCopied.checkLock(eThr, lockHold, 3)) {
+                if(!depCopied.thrG2.get(eThr) && (depCopied.exclThreadsAftG1.get(eThr) || (!depCopied.inclThreadsAftG1.get(eThr) && depCopied.exclThreadsBefG1.get(eThr) && !depCopied.thrG1.get(eThr)))) {
+                    depCopied.Frontier.update(eThr, eDec, eType);
+                }
+                if(eType == EventType.JOIN.ordinal()) {
+                    if(!depCopied.thrG2.get(eDec) && (depCopied.exclThreadsAftG1.get(eDec) || (!depCopied.inclThreadsAftG1.get(eDec) && depCopied.exclThreadsBefG1.get(eDec) && !depCopied.thrG1.get(eDec)))) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                }
+                depCopied.thrG2.set(eThr);
+                depCopied.exclThreadsAftG1.set(eThr);
+                if(eType == EventType.FORK.ordinal() || eType == EventType.JOIN.ordinal()) {
+                    depCopied.exclThreadsAftG1.set(eDec);
+                }
+                if(eType == EventType.READ.ordinal() && !depCopied.wtG2.get(eDec)) {
+                    if( depCopied.exclWtVarsAftG1.get(eDec) || 
+                        (depCopied.inclWtVarsAftG1.get(eDec) && depCopied.wtG1.get(eDec))) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                }
+                if(eType == EventType.WRITE.ordinal()) {
+                    depCopied.wtG2.set(eDec);
+                    depCopied.exclWtVarsAftG1.set(eDec);
+                }
+                if(eType == EventType.ACQUIRE.ordinal()) {
+                    if(depCopied.openLocks.get(eDec) || depCopied.openLocksG1.get(eDec)) {
+                        depCopied.Frontier.update(eThr, eDec, eType);
+                    }
+                }
+                if(depCopied.Frontier.isDependentWith(eThr, eDec, eType)) {
+                    depCopied.Frontier.update(eThr, eDec, eType);
+                }
+                if(eThr == depCopied.e1Thr || ((eType == EventType.WRITE.ordinal() || (eType == EventType.READ.ordinal() && depCopied.e1Write)) && depCopied.e1Var == eDec) || ((eType == EventType.FORK.ordinal() || eType == EventType.JOIN.ordinal()) && eDec == depCopied.e1Thr)) {
+                    depCopied.Frontier.update(eThr, eDec, eType);
+                }
+                addToStates13(newStates, newBirths, depCopied, birth, 3);
+            }
+            }
+
+            // choose as e2
+            {
+                if(eThr != dep.e1Thr && (eType == EventType.WRITE.ordinal() || (eType == EventType.READ.ordinal() && dep.e1Write)) && dep.e1Var == eDec) {
+                    if((dep.thrG2.get(eThr) || (!dep.exclThreadsAftG1.get(eThr) && (dep.inclThreadsAftG1.get(eThr) || !dep.exclThreadsBefG1.get(eThr) || dep.thrG1.get(eThr)))) && !dep.Frontier.isDependentWith(eThr, eDec, eType)) {
+                        DependentInfo depCopied = new DependentInfo(dep); 
+                        if (depCopied.checkLock(eThr, lockHold, 3)) {
+                            // System.out.println(eventCount + " " + eThr + " " + eDec + " " + depCopied);
+                            racy = true;
+                        }   
+                    }
+                }
+            } 
+        }
+        statesPhase3 = newStates;
+        birthsPhase3 = newBirths;
+    }
+
+    private void addToStates13(HashMap<String, DependentInfo> states, PriorityQueue<Long> births, DependentInfo dep, long birth, int phase) {
+        BitSet exlthreadsTotal = (BitSet)dep.exclThreadsBefG1.clone();
+        exlthreadsTotal.or(dep.exclThreadsAftG1);
+        if(phase == 1 && exlthreadsTotal.nextClearBit(0) == numOfThreads) {
+            return;
+        }
+        dep.birth = birth;
+        dep.hashString = dep.toString();
+        if(states.containsKey(dep.hashString)) {
+            DependentInfo depDup = states.get(dep.hashString);
+            if(depDup.birth < birth) {
+                if(LRU) {
+                    births.remove(depDup.birth);
+                    births.add(birth);
+                }
+                depDup.birth = birth;
+            }
+            return;
+        }
+        if(phase == 1 || phase == 3) {
+            for(Iterator<Entry<String, DependentInfo>> it = states.entrySet().iterator(); it.hasNext();) {
+                DependentInfo depInfo = it.next().getValue();
+                if((phase == 0 && depInfo.subsumePhase0(dep, lockHold2)) || (phase == 2 && depInfo.subsumePhase2(dep, lockHold2))) {
+                    return;
+                }
+                if((phase == 0 && depInfo.subsumePhase0(dep, lockHold2)) || (phase == 2 && depInfo.subsumePhase2(dep, lockHold2))) {
+                    it.remove();
+                    births.remove(depInfo.birth);
+                }
+            }
+        }
+        
+        if(LRU) {
+            if(birth != 0) {
+                if(births.size() >= poolSize) {
+                    if(births.peek() < birth) {
+                        births.poll();
+                        births.add(birth);
+                        states.put(dep.hashString, dep);
+                    }
+                }
+                else {
+                    births.add(birth);
+                    states.put(dep.hashString, dep);
+                }
+            }
+            else {
+                states.put(dep.hashString, dep);
+            }
+        }
+        
+    }
+
+    private void addToStates02(HashMap<Integer, HashMap<String, DependentInfo>> states, PriorityQueue<Long> births, DependentInfo dep, long birth, int phase) {
+        BitSet exlthreadsTotal = (BitSet)dep.exclThreadsBefG1.clone();
+        exlthreadsTotal.or(dep.exclThreadsAftG1);
+        if(exlthreadsTotal.nextClearBit(0) == numOfThreads) {
+            return;
+        }
+        dep.birth = birth;
+        dep.hashString = dep.toString();
+        if(!states.containsKey(dep.e1Var)) {
+            states.put(dep.e1Var, new HashMap<>());
+        }
+        HashMap<String, DependentInfo> substates = states.get(dep.e1Var);
+        if(substates.containsKey(dep.hashString)) {
+            DependentInfo depDup = substates.get(dep.hashString);
+            if(depDup.birth < birth) {
+                if(LRU) {
+                    births.remove(depDup.birth);
+                    births.add(birth);
+                }
+                depDup.birth = birth;
+            }
+            return;
+        }
+        if(phase == 0 || phase == 2) {
+            for(Iterator<Entry<String, DependentInfo>> it = substates.entrySet().iterator(); it.hasNext();) {
+                DependentInfo depInfo = it.next().getValue();
+                if((phase == 0 && depInfo.subsumePhase0(dep, lockHold2)) || (phase == 2 && depInfo.subsumePhase2(dep, lockHold2))) {
+                    return;
+                }
+                if((phase == 0 && depInfo.subsumePhase0(dep, lockHold2)) || (phase == 2 && depInfo.subsumePhase2(dep, lockHold2))) {
+                    it.remove();
+                    births.remove(depInfo.birth);
+                }
+            }
+        }
+        if(LRU) {
+            if(birth != 0) {
+                if(births.size() >= poolSize) {
+                    if(births.peek() < birth) {
+                        births.poll();
+                        births.add(birth);
+                        substates.put(dep.hashString, dep);
+                    }
+                }
+                else {
+                    births.add(birth);
+                    substates.put(dep.hashString, dep);
+                }
+            }
+            else {
+                substates.put(dep.hashString, dep);
+            }
+        }
+        
+    }
+
+    public void printMemory() {
+    }
+}
+
+class DependentInfo {
+    public BitSet exclThreadsBefG1;
+    public BitSet exclThreadsAftG1;
+    public BitSet inclThreadsAftG1;
+    public BitSet exclWtVarsBefG1;
+    public BitSet exclWtVarsAftG1;
+    public BitSet inclWtVarsAftG1;
+    public BitSet openLocks;
+
+    public int e1Var;
+    public int e1Thr;
+    public boolean e1Write;
+    public int e1Acq;
+
+    public BitSet thrG1;
+    public BitSet wtG1;
+    public BitSet openLocksG1;
+
+    public BitSet thrG2;
+    public BitSet wtG2;
+
+    public MazFrontier Frontier;
+    public HashMap<Integer, MazFrontier> rdFrontier;
+    public HashMap<Integer, MazFrontier> acqFrontier;
+    public int G1Size;
+    public int G2Size;
+    // public int G1Time;
+    // public int activeAcq;
+
+    public long birth;
+    public boolean pin;
+
+    public String hashString;
+
+    public DependentInfo() {
+        exclThreadsBefG1 = new BitSet(State.numOfThreads);
+        exclThreadsAftG1 = new BitSet(State.numOfThreads);
+        inclThreadsAftG1 = new BitSet(State.numOfThreads);
+        exclWtVarsBefG1 = new BitSet(State.numOfVariables); 
+        exclWtVarsAftG1 = new BitSet(State.numOfVariables);
+        inclWtVarsAftG1 = new BitSet(State.numOfVariables);
+        openLocks = new BitSet(State.numOfLocks); 
+        e1Var = -1;
+        e1Thr = -1;
+        pin = false;
+        e1Write = false;
+        e1Acq = -1;
+        thrG1 = new BitSet(State.numOfThreads);
+        wtG1 = new BitSet(State.numOfVariables);
+        openLocksG1 = new BitSet(State.numOfLocks);
+        thrG2 = new BitSet(State.numOfThreads);
+        wtG2 = new BitSet(State.numOfVariables); 
+        Frontier = new MazFrontier();
+        rdFrontier = new HashMap<>();
+        acqFrontier = new HashMap<>();
+        G1Size = 0;
+        G2Size = 0;
+        // G1Time = 0;
+        // activeAcq = 0;
+        birth = 0;
+        hashString = toString();
+    }
+
+    public DependentInfo(DependentInfo other) {
+        exclThreadsBefG1 = (BitSet)other.exclThreadsBefG1.clone();
+        exclThreadsAftG1 = (BitSet)other.exclThreadsAftG1.clone();
+        inclThreadsAftG1 = (BitSet)other.inclThreadsAftG1.clone();
+        exclWtVarsBefG1 = (BitSet)other.exclWtVarsBefG1.clone(); 
+        exclWtVarsAftG1 = (BitSet)other.exclWtVarsAftG1.clone();
+        inclWtVarsAftG1 = (BitSet)other.inclWtVarsAftG1.clone();
+        openLocks = (BitSet)other.openLocks.clone(); 
+        e1Var = other.e1Var;
+        e1Thr = other.e1Thr;
+        e1Write = other.e1Write;
+        e1Acq = other.e1Acq;
+        pin = other.pin;
+        thrG1 = (BitSet)other.thrG1.clone();
+        wtG1 = (BitSet)other.wtG1.clone();
+        openLocksG1 = (BitSet)other.openLocksG1.clone();
+        thrG2 = (BitSet)other.thrG2.clone();
+        wtG2 = (BitSet)other.wtG2.clone(); 
+        Frontier = new MazFrontier(other.Frontier);
+        if(other.rdFrontier == null) {
+            rdFrontier = null;
+        }
+        else {
+            rdFrontier = new HashMap<>();
+            for(int l: other.rdFrontier.keySet()) {
+                rdFrontier.put(l, new MazFrontier(other.rdFrontier.get(l)));
+            }
+        }
+        if(other.acqFrontier == null) {
+            acqFrontier = null;
+        }
+        else {
+            acqFrontier = new HashMap<>();
+            for(int l: other.acqFrontier.keySet()) {
+                acqFrontier.put(l, new MazFrontier(other.acqFrontier.get(l)));
+            }
+        }
+        this.G1Size = other.G1Size;
+        this.G2Size = other.G2Size;
+        // this.G1Time = other.G1Time;
+        // this.activeAcq = other.activeAcq;
+        birth = other.birth;
+        hashString = toString();
+    }
+
+
+    public boolean mustIgnore(int eThr, int eDec, int eType){
+        boolean ignoreBefG1 = (exclThreadsBefG1.get(eThr)) ||
+            (eType == EventType.ACQUIRE.ordinal() && openLocks.get(eDec)) ||
+            (eType == EventType.READ.ordinal() && exclWtVarsBefG1.get(eDec) && !inclWtVarsAftG1.get(eDec)) ||
+            (eType == EventType.JOIN.ordinal() && exclThreadsBefG1.get(eDec));
+        boolean ignoreAftG1 = (exclThreadsAftG1.get(eThr)) ||
+            (eType == EventType.ACQUIRE.ordinal() && openLocks.get(eDec)) ||
+            (eType == EventType.READ.ordinal() && exclWtVarsAftG1.get(eDec)) ||
+            (eType == EventType.JOIN.ordinal() && exclThreadsAftG1.get(eDec));
+        return ignoreBefG1 || ignoreAftG1;
+	}
+
+    public boolean checkLock(int eThr, HashMap<Integer, HashMap<Integer, Integer>> lockHold, int phase) {
+        if( (phase == 0 && !exclThreadsBefG1.get(eThr)) ||
+        (phase == 1 && !thrG1.get(eThr) && !exclThreadsBefG1.get(eThr)) ||
+        (phase == 2 && !exclThreadsAftG1.get(eThr) && !exclThreadsBefG1.get(eThr)) ||
+        (phase == 3 && !thrG2.get(eThr) && !exclThreadsAftG1.get(eThr) && !exclThreadsBefG1.get(eThr))) {
+            for(int lck: lockHold.get(eThr).keySet()) {
+                openLocks.set(lck);
+                if(acqFrontier != null && acqFrontier.containsKey(lck)) {
+                    MazFrontier fr = acqFrontier.get(lck);
+                    if(fr.isDependentWithE1) {
+                        return false;
+                    }
+                    else {
+                        Frontier.union(fr);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean ignore(int eThr, int eDec, int eType, HashMap<Integer, HashMap<Integer, Integer>> lockHold, int phase) {
+        if(!checkLock(eThr, lockHold, phase)) {
+            return false;
+        }
+
+        if (phase == 0 || phase == 1) {
+            exclThreadsBefG1.set(eThr);
+        }
+        else {
+            exclThreadsAftG1.set(eThr);
+        }
+        if(eType == EventType.WRITE.ordinal()) {
+            if(phase == 0 || phase == 1) {
+                exclWtVarsBefG1.set(eDec);
+            }
+            else {
+                exclWtVarsAftG1.set(eDec);
+            }
+        }
+        if(eType == EventType.FORK.ordinal() || eType == EventType.JOIN.ordinal()) {
+            if (phase == 0 || phase == 1) {
+                exclThreadsBefG1.set(eDec);
+            }
+            else {
+                exclThreadsAftG1.set(eDec);
+            }
+        }
+        return true;
+    }
+
+    private boolean subsume(BitSet b1, BitSet b2) {
+        BitSet b1Clone = (BitSet)b1.clone();
+        b1Clone.andNot(b2);
+        return b1Clone.isEmpty();
+    }    
+
+    private boolean subsumeOpenLock(BitSet t1, BitSet t2, BitSet l2, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+        BitSet t1Clone = (BitSet)t1.clone();
+        t1Clone.andNot(t2);
+        for(int i = t1Clone.nextSetBit(0); i >= 0; i = t1Clone.nextSetBit(i+1)) {
+            if(lockHold.containsKey(i)) {
+                for(int lck: lockHold.get(i).keySet()) {
+                    if(!l2.get(lck)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean subsumePhase0(DependentInfo other, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+
+        return  subsume(this.exclThreadsBefG1, other.exclThreadsBefG1) &&
+                subsume(this.exclWtVarsBefG1, other.exclWtVarsBefG1) &&
+                subsume(this.openLocks, other.openLocks) && 
+                subsumeOpenLock(other.exclThreadsBefG1, this.exclThreadsBefG1, other.openLocks, lockHold);         
+    }
+
+    public boolean subsumePhase2(DependentInfo other, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+        BitSet thisCombineExclThreads = (BitSet)this.exclThreadsBefG1.clone();
+        thisCombineExclThreads.or(this.exclThreadsAftG1);
+        BitSet otherCombineExclThreads = (BitSet)other.exclThreadsBefG1.clone();
+        otherCombineExclThreads.or(other.exclThreadsAftG1);
+
+        BitSet thisCombineExclWtVars = (BitSet)this.exclWtVarsBefG1.clone();
+        thisCombineExclWtVars.andNot(this.inclWtVarsAftG1);
+        thisCombineExclWtVars.or(this.exclWtVarsAftG1);
+        BitSet otherCombineExclWtVars = (BitSet)other.exclWtVarsBefG1.clone();
+        otherCombineExclWtVars.andNot(other.inclWtVarsAftG1);
+        otherCombineExclWtVars.or(other.exclWtVarsAftG1); 
+        return  this.pin &&
+                this.e1Var == other.e1Var &&
+                (this.e1Write || !other.e1Write) && 
+                subsume(thisCombineExclThreads, otherCombineExclThreads) &&
+                subsume(thisCombineExclWtVars, otherCombineExclWtVars) &&
+                subsume(this.openLocks, other.openLocks) && 
+                subsumeOpenLock(otherCombineExclThreads, thisCombineExclThreads, other.openLocks, lockHold);         
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(exclThreadsBefG1);
+        sb.append(exclThreadsAftG1);
+        sb.append(inclThreadsAftG1);
+        sb.append(exclWtVarsBefG1);
+        sb.append(exclWtVarsAftG1);
+        sb.append(inclWtVarsAftG1);
+        sb.append(openLocks);
+
+        sb.append(e1Thr);
+        sb.append(e1Var);
+        sb.append(e1Write);
+        sb.append(e1Acq);
+        sb.append(pin);
+
+        sb.append(thrG1);
+        sb.append(wtG1);
+        sb.append(openLocksG1);
+
+        sb.append(thrG2);
+        sb.append(wtG2);
+
+        sb.append(Frontier);
+        sb.append(rdFrontier);
+        sb.append(acqFrontier);
+        sb.append(G1Size);
+        sb.append(G2Size);
+        // sb.append(G1Time);
+        // sb.append(activeAcq);
+        return sb.toString();
+    }
+
+}
+
+class MazFrontier {
+    public BitSet threads;
+    public BitSet rdVars;
+    public BitSet wtVars;
+    public BitSet locks;
+    public boolean isDependentWithE1;
+
+    public MazFrontier() {
+        threads = new BitSet(State.numOfThreads);
+        rdVars = new BitSet(State.numOfVariables);
+        wtVars = new BitSet(State.numOfVariables); 
+        locks = new BitSet(State.numOfLocks);
+        isDependentWithE1 = false;
+    }
+
+    public MazFrontier(MazFrontier other) {
+        threads = (BitSet)other.threads.clone();
+        rdVars = (BitSet)other.rdVars.clone();
+        wtVars = (BitSet)other.wtVars.clone();
+        locks = (BitSet)other.locks.clone();
+        isDependentWithE1 = other.isDependentWithE1;
+    }
+
+    public boolean isDependentWith(int eThr, int eDec, int eType) {
+        if(threads.get(eThr)) {
+            return true;
+        }
+        if((eType == EventType.JOIN.ordinal() || eType == EventType.FORK.ordinal()) && threads.get(eDec)) {
+            return true;
+        }
+        if(eType == EventType.READ.ordinal() && wtVars.get(eDec)) {
+            return true;
+        }
+        if(eType == EventType.WRITE.ordinal() && (wtVars.get(eDec) || rdVars.get(eDec))) {
+            return true;
+        }
+        if((eType == EventType.ACQUIRE.ordinal() || eType == EventType.RELEASE.ordinal()) && locks.get(eDec)) {
+            return true;
+        }
+        return false;
+    }
+
+    public void update(int eThr, int eDec, int eType) {
+        threads.set(eThr);
+        if(eType == EventType.JOIN.ordinal() || eType == EventType.FORK.ordinal()) {
+            threads.set(eDec);
+        }
+        if(eType == EventType.READ.ordinal()) {
+            rdVars.set(eDec);
+        }
+        if(eType == EventType.WRITE.ordinal()) {
+            wtVars.set(eDec);
+        }
+        if(eType == EventType.ACQUIRE.ordinal() || eType == EventType.RELEASE.ordinal()) {
+            locks.set(eDec);
+        }
+    }
+
+    public void union(MazFrontier other) {
+        threads.or(other.threads);
+        rdVars.or(other.rdVars);
+        wtVars.or(other.wtVars);
+        locks.or(other.locks);
+    }
+
+    private boolean subsume(BitSet b1, BitSet b2) {
+        BitSet b1Clone = (BitSet)b1.clone();
+        b1Clone.andNot(b2);
+        return b1Clone.isEmpty();
+    }
+
+    public boolean subsume(MazFrontier other) {
+        return !this.threads.isEmpty() && !other.threads.isEmpty() && subsume(this.threads, other.threads) && subsume(this.wtVars, other.wtVars) && subsume(this.rdVars, other.rdVars) && subsume(this.locks, other.locks) && this.isDependentWithE1 == other.isDependentWithE1;
+    }
+
+    public void toString(StringBuffer sb) {
+        sb.append(threads);
+        sb.append(wtVars);
+        sb.append(rdVars);
+        sb.append(locks);
+        sb.append(isDependentWithE1);
+    }
+
+    public String toString(){
+        StringBuffer sb = new StringBuffer();
+        sb.append(threads);
+        sb.append(wtVars);
+        sb.append(rdVars);
+        sb.append(locks);
+        sb.append(isDependentWithE1);
+        return sb.toString();
+    }
+}
+
+class DependentInfoComparator implements Comparator<DependentInfo> {
+    public int compare(DependentInfo o1, DependentInfo o2) {
+        return o1.hashString.compareTo(o2.hashString);
+    }
+}

--- a/src/engine/racedetectionengine/grainSeqP/cmd/GrainSeqPCmdOptions.java
+++ b/src/engine/racedetectionengine/grainSeqP/cmd/GrainSeqPCmdOptions.java
@@ -1,0 +1,24 @@
+package engine.racedetectionengine.grainSeqP.cmd;
+
+import cmd.CmdOptions;
+
+public class GrainSeqPCmdOptions extends CmdOptions {
+	
+	public int grainSize;
+	public boolean doGrainSize;
+	public boolean doGrainPattern;
+	public boolean doLRU;
+	public int LRUSize;
+	public boolean doSubsumption;
+
+	public GrainSeqPCmdOptions() {
+		super();
+		this.doGrainSize = false;
+		this.doGrainPattern = false;
+		this.doLRU = false;
+		this.grainSize = 0;
+		this.LRUSize = 0;
+		this.doSubsumption = false;
+	}
+
+}

--- a/src/engine/racedetectionengine/grainSeqP/cmd/GrainSeqPGetOptions.java
+++ b/src/engine/racedetectionengine/grainSeqP/cmd/GrainSeqPGetOptions.java
@@ -1,37 +1,30 @@
-package cmd;
+package engine.racedetectionengine.grainSeqP.cmd;
 
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
 import parse.ParserType;
+import cmd.GetOptions;
 
-public class GetOptions {
+public class GrainSeqPGetOptions extends GetOptions {
 
-	protected static final Logger log = Logger.getLogger(GetOptions.class.getName());
-	protected String[] args = null;
-	protected Options options = new Options();
-
-	public GetOptions(String[] args) {
-		this.args = args;
-		options.addOption("h", "help", false, "generate this message");
-		options.addOption("f", "format", true, "format of the trace. Possible choices include rv, csv, rr, std (Default : csv) ");
-		options.addOption("s", "single", false, "force the algorithm to terminate after the first race is detected");
-		options.addOption("p", "path", true, "the path to the trace file/folder (Required)");
-		options.addOption("v", "verbosity", true, "for setting verbosity: Allowed levels = 0, 1, 2 (Default : 0)");
-        options.addOption("m", "excluded-methods", true, "path to file that lists methods to be excluded");
+	public GrainSeqPGetOptions(String[] args) {
+		super(args);
+		options.addOption("lru", "lru", true, "Argument of Heuristic Optimizations");
+		options.addOption("gs", "grainSize", true, "Heuristic Optimizations");
+		options.addOption("gp", "grainPattern", false, "Heuristic Optimizations");
+		options.addOption("sub", "subsumption", false, "Heuristic Optimizations");
 	}
 
-	public CmdOptions parse() {
+	public GrainSeqPCmdOptions parse() {
 		CommandLineParser parser = new DefaultParser();
 		CommandLine cmd = null;
-		CmdOptions cmdOpt = new CmdOptions();;
+		GrainSeqPCmdOptions cmdOpt = new GrainSeqPCmdOptions();;
 
 		try {
 			cmd = parser.parse(options, args);
@@ -70,6 +63,24 @@ public class GetOptions {
                 cmdOpt.excludeList = cmd.getOptionValue("m") ;   
             }
 
+			if (cmd.hasOption("lru")) {
+				cmdOpt.doLRU = true;
+				cmdOpt.LRUSize = Integer.parseInt(cmd.getOptionValue("lru"));
+			}
+
+			if (cmd.hasOption("gs")) {
+				cmdOpt.doGrainSize = true;
+				cmdOpt.grainSize = Integer.parseInt(cmd.getOptionValue("gs"));
+			}
+
+			if(cmd.hasOption("gp")) {
+				cmdOpt.doGrainPattern = true;
+			}
+
+			if(cmd.hasOption("sub")) {
+				cmdOpt.doSubsumption = true;
+			}
+
 		} catch (ParseException e) {
 			help();
 		}
@@ -84,6 +95,6 @@ public class GetOptions {
 	}
 
 	public static void main(String[] args) {
-		new GetOptions(args).parse();
+		new GrainSeqPGetOptions(args).parse();
 	}
 }

--- a/src/engine/racedetectionengine/seqpreserving/PrefixEngine.java
+++ b/src/engine/racedetectionengine/seqpreserving/PrefixEngine.java
@@ -1,0 +1,148 @@
+package engine.racedetectionengine.seqpreserving;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashSet;
+import java.util.Scanner;
+
+import engine.Engine;
+import engine.racedetectionengine.seqpreserving.preprocess.PreprocessEngine;
+import event.Thread;
+import it.unimi.dsi.fastutil.Hash;
+import parse.ParserType;
+import parse.rr.ParseRoadRunner;
+import parse.std.ParseStandard;
+
+public class PrefixEngine extends Engine<PrefixEvent> {
+    protected long eventCount;
+    protected long totalSkippedEvents;
+
+    protected int numOfThreads;
+    protected int numOfVars;
+    protected int numOfLocks;
+
+    protected State state;
+    protected String sourceFile;
+
+    HashSet<Long> racyevents = new HashSet<>();
+    HashSet<Integer> racyLocs = new HashSet<>();
+
+    HashSet<Integer> protectedVars;
+    public boolean partition = false;
+    long startTimeAnalysis = 0;
+
+    public PrefixEngine(ParserType pType, String trace_folder, boolean subsumption) {
+        super(pType);
+        sourceFile = trace_folder;
+        eventCount = 0;
+        totalSkippedEvents = 0;
+        this.initializeReader(trace_folder);
+        PreprocessEngine engine = new PreprocessEngine(pType, trace_folder, stdParser);
+        engine.analyzeTrace();
+        protectedVars = engine.getProtectedVars();
+        resetSTDParser();
+        handlerEvent = new PrefixEvent();
+        eventCount = 0;
+        state = new State(numOfThreads, numOfVars, numOfLocks, protectedVars, subsumption);
+    }
+
+    protected void analyzeEvent(PrefixEvent handlerEvent, Long eventCount){
+		
+	}
+
+    public void analyzeTrace() {
+		if (this.parserType.isRR()) {
+			analyzeTraceRR();
+		}
+        if (this.parserType.isSTD()) {
+			analyzeTraceSTD();
+		}
+		printCompletionStatus();
+    }
+
+    private void analyzeTraceRR() {
+        boolean flag = false;
+        startTimeAnalysis = System.currentTimeMillis();
+        long stopTimeAnalysis = 0;
+        while(rrParser.checkAndGetNext(handlerEvent)) {
+            eventCount = eventCount + 1;
+            analyzeEvent(handlerEvent, eventCount);
+            postHandleEvent(handlerEvent);
+        }
+        if(!flag) {
+            stopTimeAnalysis = System.currentTimeMillis();
+            System.out.println("Not matched");
+        }
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for full analysis = " + timeAnalysis + " milliseconds");
+    }
+
+    private void analyzeTraceSTD() {
+        long maxState = 0;
+        long maxBirth = 0;
+        long startTimeAnalysis = System.currentTimeMillis();
+        while(stdParser.hasNext()){
+            eventCount = eventCount + 1;
+            stdParser.getNextEvent(handlerEvent);
+            try{
+                if(handlerEvent.Handle(state)) {
+                    racyevents.add(eventCount);
+                    racyLocs.add(handlerEvent.getLocId());
+                }
+            }
+            catch(OutOfMemoryError oome){
+                System.err.println("Number of events = " + Long.toString(eventCount));
+                state.printMemory();
+                oome.printStackTrace();
+            }
+            postHandleEvent(handlerEvent);
+        }
+        long stopTimeAnalysis = System.currentTimeMillis();
+        long timeAnalysis = stopTimeAnalysis - startTimeAnalysis;
+        System.out.println("Time for analysis = " + timeAnalysis + " milliseconds");
+        System.out.println("Max State Size = " + maxState + " birth = " + maxBirth);
+        System.out.println("Racy events = " + racyevents);
+        System.out.println("Racy locations = " + racyLocs);
+        System.out.println("Number of 'racy' events found = " + racyevents.size());
+    }
+
+    protected void initializeReaderRV(String trace_folder) {
+
+    }
+
+	protected void initializeReaderCSV(String trace_file) {
+
+    }
+
+	protected void initializeReaderSTD(String trace_file) {
+        stdParser = new ParseStandard(trace_file, true);
+        numOfThreads = stdParser.getNumOfThreads();
+        numOfVars = stdParser.getNumOfVars();
+        numOfLocks = stdParser.getNumOfLocks();
+    }
+
+	protected void initializeReaderRR(String trace_file) {
+        rrParser = new ParseRoadRunner(trace_file, true);
+    }
+
+    protected void resetSTDParser() {
+        stdParser.totEvents = 0;
+        try{
+            stdParser.bufferedReader = new BufferedReader(new FileReader(sourceFile));
+        }
+        catch (FileNotFoundException ex) {
+            System.out.println("Unable to open file '" + sourceFile + "'");
+        }
+    }
+
+    protected boolean skipEvent(PrefixEvent handlerEvent) {
+        // return !handlerEvent.getType().isAccessType();
+        return false;
+    }
+
+	protected void postHandleEvent(PrefixEvent handlerEvent) {
+
+    } 
+}

--- a/src/engine/racedetectionengine/seqpreserving/PrefixEvent.java
+++ b/src/engine/racedetectionengine/seqpreserving/PrefixEvent.java
@@ -1,0 +1,10 @@
+package engine.racedetectionengine.seqpreserving;
+
+import event.Event;
+
+public class PrefixEvent extends Event {
+
+    public boolean Handle(State state) {
+		return state.update(this);
+	}   
+}

--- a/src/engine/racedetectionengine/seqpreserving/State.java
+++ b/src/engine/racedetectionengine/seqpreserving/State.java
@@ -1,0 +1,270 @@
+package engine.racedetectionengine.seqpreserving;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.BitSet;
+
+import event.EventType;
+
+public class State {
+    public HashMap<Integer, HashMap<String, DependentInfo>> states = new HashMap<>();
+    public int numOfThreads;
+    public int numOfVariables;
+    public int numOfLocks;
+    public int raceCnt = 0;
+    public boolean racy = false;
+    public long timestamp;
+    private boolean subsumption;
+    private HashMap<Integer, HashMap<Integer, Integer>> lockHold = new HashMap<>();
+    private HashMap<Integer, HashMap<Integer, Integer>> lockHold2 = new HashMap<>();
+    public HashSet<Integer> racyLocs = new HashSet<>();
+    HashSet<Integer> protectedVars;
+
+    public State(int numOfThreads, int numOfVars, int numOfLocks, HashSet<Integer> protectedVars, boolean subsumption) {
+        this.numOfThreads = numOfThreads;
+        this.numOfVariables = numOfVars;
+        this.numOfLocks = numOfLocks;
+        this.subsumption = subsumption;
+        this.protectedVars = protectedVars;
+
+        DependentInfo dep = new DependentInfo(numOfThreads, numOfVariables, numOfLocks);
+        HashMap<String, DependentInfo> substates = new HashMap<>();
+        substates.put(dep.hashString, dep);
+        states.put(-1, substates);
+    };
+
+    public boolean update(PrefixEvent e) {
+        int eThr = e.getThread().getId();
+        int eDec = -1;
+        int eType = e.getType().ordinal();
+        if(e.getType().isAccessType()) {
+            eDec = e.getVariable().getId();
+        }
+        else if(e.getType().isLockType()) {
+            eDec = e.getLock().getId();
+        }
+        else if(e.getType().isExtremeType()) {
+            eDec = e.getTarget().getId();
+        }
+
+        HashMap<Integer, HashMap<String, DependentInfo>> newStates = new HashMap<>();
+        boolean matched = false;
+        timestamp++;
+        if(!lockHold.containsKey(eThr)) {
+			lockHold.put(eThr, new HashMap<>());
+		}
+        if(!lockHold2.containsKey(eThr)) {
+			lockHold2.put(eThr, new HashMap<>());
+		}
+
+        if(eType == EventType.ACQUIRE.ordinal()) {
+            if(!lockHold2.get(eThr).containsKey(eDec)) {
+                lockHold2.get(eThr).put(eDec, 0);
+            }
+			lockHold2.get(eThr).put(eDec, lockHold2.get(eThr).get(eDec) + 1);
+		}
+		if(eType == EventType.RELEASE.ordinal()) {
+			assert(lockHold2.get(eThr).get(eDec) > 0);
+            lockHold2.get(eThr).put(eDec, lockHold2.get(eThr).get(eDec) - 1);
+            if(lockHold2.get(eThr).get(eDec) == 0) {
+                lockHold2.get(eThr).remove(eDec);
+            }
+		}
+
+        for(int var: states.keySet()) {
+            HashMap<String, DependentInfo> substates = states.get(var);
+            for(String hashString: substates.keySet()){
+                DependentInfo dep = substates.get(hashString);
+    
+                if(!racy && e.getType().isAccessType() && dep.candVar == eDec && !dep.threads.get(eThr)) {
+                    if(dep.isWriteCandidate || eType == EventType.WRITE.ordinal()) {
+                        racy = true;
+                    }
+                }
+    
+                if(dep.mustIgnore(eThr, eDec, eType)) {
+                    if(dep.candVar == -1 && e.getType().isRead() && !protectedVars.contains(eDec) && !dep.threads.get(eThr)) {
+                        DependentInfo depCopied = new DependentInfo(dep);
+                        depCopied.ignore(eThr, eDec, eType, lockHold);
+                        depCopied.candVar = eDec;
+                        depCopied.isWriteCandidate = false;
+                        depCopied.hashString = depCopied.toString(); 
+                        addToStates(newStates, depCopied);
+                    }
+                    dep.ignore(eThr, eDec, eType, lockHold);
+                    
+                }
+                else {
+                    if(((e.getType().isAccessType() && dep.candVar == -1 && !protectedVars.contains(eDec))) || (e.getType().isAcquire() && dep.candVar != -1)) {
+                        DependentInfo depCopied = new DependentInfo(dep);
+                        if(e.getType().isAccessType()) {
+                            depCopied.candVar = eDec;
+                            depCopied.isWriteCandidate = e.getType().isWrite();
+                        }
+                        depCopied.ignore(eThr, eDec, eType, lockHold);
+                        depCopied.hashString = depCopied.toString();
+                        if(depCopied.threads.size() != numOfThreads) {
+                            addToStates(newStates, depCopied);
+                        }
+                    }
+    
+                    // II. Keep event e:
+                    if(e.getType().isWrite()) {
+                        dep.wtVars.clear(eDec);
+                    } 
+                }
+                dep.hashString = dep.toString();
+                addToStates(newStates, dep);
+            }
+        }
+        
+        states = newStates;
+        if(racy) {
+            raceCnt++;
+            matched = true;
+        }
+        racy = false;
+        if(eType == EventType.ACQUIRE.ordinal()) {
+            if(!lockHold.get(eThr).containsKey(eDec)) {
+                lockHold.get(eThr).put(eDec, 0);
+            }
+			lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) + 1);
+		}
+		if(eType == EventType.RELEASE.ordinal()) {
+			assert(lockHold.get(eThr).get(eDec) > 0);
+            lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) - 1);
+            if(lockHold.get(eThr).get(eDec) == 0) {
+                lockHold.get(eThr).remove(eDec);
+            }
+		}
+        return matched;
+    }
+
+    private void addToStates(HashMap<Integer, HashMap<String, DependentInfo>> states, DependentInfo dep) {
+        if(!states.containsKey(dep.candVar)) {
+            states.put(dep.candVar, new HashMap<>());
+        }
+        HashMap<String, DependentInfo> substates = states.get(dep.candVar);
+        dep.hashString = dep.toString();
+        if(substates.containsKey(dep.hashString)) {
+            return;
+        }
+        if(subsumption) {
+            for(Iterator<Entry<String, DependentInfo>> it = substates.entrySet().iterator(); it.hasNext();) {
+                DependentInfo depInfo = it.next().getValue();
+                if(depInfo.subsume(dep, lockHold2)) {
+                    return;
+                }
+                if(dep.subsume(depInfo, lockHold2)) {
+                    it.remove();
+                }
+            }
+        }
+        substates.put(dep.hashString, dep);
+    }
+
+    public void printMemory() {
+        System.out.println(states.size());
+    }
+}
+
+class DependentInfo {
+    public BitSet threads;
+    public BitSet wtVars;
+    public BitSet openLocks;
+
+    public int candVar;
+    public boolean isWriteCandidate;
+
+    public String hashString;
+
+    public DependentInfo(int numOfThr, int numOfVar, int numOfLck) {
+        threads = new BitSet(numOfThr);
+        wtVars = new BitSet(numOfVar);
+        openLocks = new BitSet(numOfLck);
+        candVar = -1;
+        isWriteCandidate = false;
+        hashString = toString();
+    }
+
+    public DependentInfo(DependentInfo other) {
+        threads = (BitSet)other.threads.clone();
+        wtVars = (BitSet)other.wtVars.clone();
+        openLocks = (BitSet)other.openLocks.clone();
+        candVar = other.candVar;
+        isWriteCandidate = other.isWriteCandidate;
+    }
+
+    public boolean mustIgnore(int eThr, int eDec, int eType){
+        return  (threads.get(eThr)) ||
+                (eType == EventType.ACQUIRE.ordinal() && openLocks.get(eDec)) ||
+                (eType == EventType.READ.ordinal() && wtVars.get(eDec)) ||
+                (eType == EventType.JOIN.ordinal() && threads.get(eDec));
+	}
+
+    public void ignore(int eThr, int eDec, int eType, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+        if(!threads.get(eThr)) {
+            for(int lck: lockHold.get(eThr).keySet()) {
+                openLocks.set(lck);
+            }
+        }
+        threads.set(eThr);
+        if(eType == EventType.WRITE.ordinal()) {
+            wtVars.set(eDec);
+        }
+        if(eType == EventType.FORK.ordinal()) {
+            threads.set(eDec);
+        }
+    }
+
+    private boolean subsume(BitSet b1, BitSet b2) {
+        BitSet b1Clone = (BitSet)b1.clone();
+        b1Clone.andNot(b2);
+        return b1Clone.isEmpty();
+    }    
+
+    private boolean subsumeOpenLock(BitSet t1, BitSet t2, BitSet l2, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+        BitSet t2Clone = (BitSet)t2.clone();
+        t2Clone.andNot(t1);
+        for(int i = t2Clone.nextSetBit(0); i >= 0; i = t2Clone.nextSetBit(i+1)) {
+            if(lockHold.containsKey(i)) {
+                for(int lck: lockHold.get(i).keySet()) {
+                    if(!l2.get(lck)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    public boolean subsume(DependentInfo other, HashMap<Integer, HashMap<Integer, Integer>> lockHold) {
+
+        return  this.candVar == other.candVar &&
+                (this.isWriteCandidate || !other.isWriteCandidate) &&
+                subsume(this.threads, other.threads) &&
+                subsume(this.wtVars, other.wtVars) &&
+                subsume(this.openLocks, other.openLocks) && 
+                subsumeOpenLock(this.threads, other.threads, other.openLocks, lockHold);
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(threads);
+        sb.append(wtVars);
+        sb.append(openLocks);
+        sb.append(candVar);
+        sb.append(isWriteCandidate ? "W" : "R");
+        return sb.toString();
+    }
+
+}
+
+class DependentInfoComparator implements Comparator<DependentInfo> {
+    public int compare(DependentInfo o1, DependentInfo o2) {
+        return o1.hashString.compareTo(o2.hashString);
+    }
+}

--- a/src/engine/racedetectionengine/seqpreserving/preprocess/PreprocessEngine.java
+++ b/src/engine/racedetectionengine/seqpreserving/preprocess/PreprocessEngine.java
@@ -1,0 +1,113 @@
+package engine.racedetectionengine.seqpreserving.preprocess;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.HashSet;
+
+import engine.Engine;
+import parse.ParserType;
+import parse.rr.ParseRoadRunner;
+import parse.std.ParseStandard;
+
+public class PreprocessEngine extends Engine<PreprocessEvent> {
+    protected long eventCount;
+    protected long totalSkippedEvents;
+
+    protected State state;
+    protected String sourceFile;
+
+    HashSet<Long> racyevents = new HashSet<>();
+    HashSet<Integer> racyLocs = new HashSet<>();
+
+    public boolean partition = false;
+    long startTimeAnalysis = 0;
+
+    public PreprocessEngine(ParserType pType, String trace_folder, ParseStandard stdParser) {
+        super(pType);
+        sourceFile = trace_folder;
+        eventCount = 0;
+        totalSkippedEvents = 0;
+        this.stdParser = stdParser;
+        handlerEvent = new PreprocessEvent();
+        eventCount = 0;
+        state = new State();
+    }
+
+    protected void analyzeEvent(PreprocessEvent handlerEvent, Long eventCount){
+		
+	}
+
+    public void analyzeTrace() {
+		if (this.parserType.isRR()) {
+			analyzeTraceRR();
+		}
+        if (this.parserType.isSTD()) {
+			analyzeTraceSTD();
+		}
+		printCompletionStatus();
+    }
+
+    private void analyzeTraceRR() {
+        while(rrParser.checkAndGetNext(handlerEvent)) {
+            eventCount = eventCount + 1;
+            analyzeEvent(handlerEvent, eventCount);
+            postHandleEvent(handlerEvent);
+        }
+    }
+
+    private void analyzeTraceSTD() {
+        while(stdParser.hasNext()){
+            eventCount = eventCount + 1;
+            stdParser.getNextEvent(handlerEvent);
+            try{
+                handlerEvent.Handle(state);
+            }
+            catch(OutOfMemoryError oome){
+                System.err.println("Number of events = " + Long.toString(eventCount));
+                state.printMemory();
+                oome.printStackTrace();
+            }
+            postHandleEvent(handlerEvent);
+        }
+    }
+
+    protected void initializeReaderRV(String trace_folder) {
+
+    }
+
+	protected void initializeReaderCSV(String trace_file) {
+
+    }
+
+	protected void initializeReaderSTD(String trace_file) {
+        stdParser = new ParseStandard(trace_file, true);
+    }
+
+	protected void initializeReaderRR(String trace_file) {
+        rrParser = new ParseRoadRunner(trace_file, true);
+    }
+
+    protected void resetSTDParser() {
+        stdParser.totEvents = 0;
+        try{
+            stdParser.bufferedReader = new BufferedReader(new FileReader(sourceFile));
+        }
+        catch (FileNotFoundException ex) {
+            System.out.println("Unable to open file '" + sourceFile + "'");
+        }
+    }
+
+    public HashSet<Integer> getProtectedVars() {
+        return state.getProtectedVars();
+    }
+
+    protected boolean skipEvent(PreprocessEvent handlerEvent) {
+        // return !handlerEvent.getType().isAccessType();
+        return false;
+    }
+
+	protected void postHandleEvent(PreprocessEvent handlerEvent) {
+
+    } 
+}

--- a/src/engine/racedetectionengine/seqpreserving/preprocess/PreprocessEvent.java
+++ b/src/engine/racedetectionengine/seqpreserving/preprocess/PreprocessEvent.java
@@ -1,0 +1,10 @@
+package engine.racedetectionengine.seqpreserving.preprocess;
+
+import event.Event;
+
+public class PreprocessEvent extends Event {
+
+    public boolean Handle(State state) {
+		return state.update(this);
+	}   
+}

--- a/src/engine/racedetectionengine/seqpreserving/preprocess/State.java
+++ b/src/engine/racedetectionengine/seqpreserving/preprocess/State.java
@@ -1,0 +1,60 @@
+package engine.racedetectionengine.seqpreserving.preprocess;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+import event.EventType;
+
+public class State {
+
+    private HashMap<Integer, HashSet<Integer>> protectedLocks = new HashMap<>(); 
+    private HashMap<Integer, HashMap<Integer, Integer>> lockHold = new HashMap<>();
+
+    public boolean update(PreprocessEvent e) {
+        int eThr = e.getThread().getId();
+        int eDec = -1;
+        int eType = e.getType().ordinal();
+        if(e.getType().isAccessType()) {
+            eDec = e.getVariable().getId();
+        }
+        else if(e.getType().isLockType()) {
+            eDec = e.getLock().getId();
+        }
+        else if(e.getType().isExtremeType()) {
+            eDec = e.getTarget().getId();
+        } 
+        if(!lockHold.containsKey(eThr)) {
+			lockHold.put(eThr, new HashMap<>());
+		}
+        if(eType == EventType.ACQUIRE.ordinal()) {
+            if(!lockHold.get(eThr).containsKey(eDec)) {
+                lockHold.get(eThr).put(eDec, 0);
+            }
+			lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) + 1);
+		}
+		if(eType == EventType.RELEASE.ordinal()) {
+			assert(lockHold.get(eThr).get(eDec) > 0);
+            lockHold.get(eThr).put(eDec, lockHold.get(eThr).get(eDec) - 1);
+            if(lockHold.get(eThr).get(eDec) == 0) {
+                lockHold.get(eThr).remove(eDec);
+            }
+		}
+        if(eType == EventType.WRITE.ordinal() || eType == EventType.READ.ordinal()) {
+            if(!protectedLocks.containsKey(eDec)) {
+                protectedLocks.put(eDec, new HashSet<>(lockHold.get(eThr).keySet()));
+            }
+            else {
+                protectedLocks.get(eDec).retainAll(lockHold.get(eThr).keySet());
+            }
+        }
+        return true;
+    }
+
+    public HashSet<Integer> getProtectedVars() {
+        return protectedLocks.keySet().stream().filter((x) -> !protectedLocks.get(x).isEmpty()).collect(Collectors.toCollection(HashSet::new));
+    }
+
+    public void printMemory() {
+    }
+}

--- a/src/event/Decoration.java
+++ b/src/event/Decoration.java
@@ -1,6 +1,8 @@
 package event;
 
-public abstract class Decoration {
+import java.io.Serializable;
+
+public abstract class Decoration implements Serializable {
 	protected int id;
 	protected String name;
 	
@@ -17,4 +19,13 @@ public abstract class Decoration {
 		//return "[Variable-" + Integer.toString(this.id) + "-" + this.name + "]";
 	}
 
+	@Override
+	public int hashCode() {
+		return id;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return this.hashCode() == obj.hashCode();
+	}
 }

--- a/src/parse/rr/ParseRoadRunner.java
+++ b/src/parse/rr/ParseRoadRunner.java
@@ -246,6 +246,10 @@ public class ParseRoadRunner {
 						}
 					}
 				}
+				if(!line.startsWith("@")) {
+					// System.out.println(line);
+					shouldExclude = true;
+				}
 				if(!shouldExclude) {
 					parser.getInfo(eInfo, line);
 					validEvent = true;

--- a/src/parse/std/ParseStandard.java
+++ b/src/parse/std/ParseStandard.java
@@ -19,11 +19,11 @@ public class ParseStandard {
 	private HashMap<String, Lock> lockMap;
 	private HashMap<String, Variable> variableMap;
 	int totThreads;
-	BufferedReader bufferedReader;
+	public BufferedReader bufferedReader;
 	String line;
 	Parse parser;
 	EventInfo eInfo;
-	long totEvents;
+	public long totEvents;
 
 	public ParseStandard(String traceFile){
 		threadMap = new HashMap<String, Thread>();
@@ -180,6 +180,18 @@ public class ParseStandard {
 
 	public int getTotalThreads(){
 		return totThreads;
+	}
+
+	public int getNumOfThreads() {
+		return this.threadMap.size();
+	}
+
+	public int getNumOfVars() {
+		return this.variableMap.size();
+	}
+
+	public int getNumOfLocks() {
+		return this.lockMap.size();
 	}
 	
 	public static void demo(){

--- a/src/util/Pair.java
+++ b/src/util/Pair.java
@@ -1,8 +1,9 @@
 package util;
 
 import java.util.Objects;
+import java.io.Serializable;
 
-public class Pair<T, U> {
+public class Pair<T, U> implements Serializable{
 	public T first;
 	public U second;
 	public Pair(T f, U s){

--- a/src/util/PipedDeepCopy.java
+++ b/src/util/PipedDeepCopy.java
@@ -1,0 +1,31 @@
+package util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+
+public class PipedDeepCopy {
+    public static Object copy(Object object) {
+        Object obj = null;
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(object);
+            oos.flush();
+            oos.close();
+            bos.close();
+            byte[] byteData = bos.toByteArray();
+            ByteArrayInputStream bais = new ByteArrayInputStream(byteData);
+            ObjectInputStream ios = new ObjectInputStream(bais);
+            obj = ios.readObject();
+            bais.close();
+            ios.close();
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+        }
+        return obj;
+    }
+
+}

--- a/src/util/vectorclock/VectorClock.java
+++ b/src/util/vectorclock/VectorClock.java
@@ -1,8 +1,9 @@
 package util.vectorclock;
 
 import java.util.Vector;
+import java.io.Serializable;
 
-public class VectorClock implements Comparable<VectorClock> {
+public class VectorClock implements Comparable<VectorClock>, Serializable {
 
 	private int dim;
 	private Vector<Integer> clock;


### PR DESCRIPTION
Add three tools under the folder engine:
1. PatternTrack: Dynamic analysis against pattern languages (on full trace or conflict-preserving prefixes)
2. SeqP: data race detection of SeqP races (originally for ConfP race detection)
3. GrainSeqP: data race detection of GrainSeqP races

Changes to shared infrastructure
1. Add features in RoadRunner parser
    - Allow parsing "VWr" and "VRd" events
    - Allow parsing of locations of transaction-type events
2. Change visibility of fields in cmd classes (private -> protected) to support customized cmd arguments parsing.
3. Add `implements Serializable` to `Decoration.java`, `VectorClock.java`, and `Pair.java` to allow deep copy of the states (in NFA simulation).